### PR TITLE
EWPP-43: Add missing module dependency.

### DIFF
--- a/oe_list_pages.post_update.php
+++ b/oe_list_pages.post_update.php
@@ -14,6 +14,5 @@ function oe_list_pages_post_update_0001() {
   \Drupal::service('module_installer')->install([
     'facets',
     'search_api',
-    'search_api_db',
   ]);
 }


### PR DESCRIPTION
## OPENEUROPA-43

### Description

The dependency to the search_api_db is missing.

### Change log

- Added: search_api_db dependency
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

