### PR TITLE
EWPP-310: Allow datetime fields to use custom processors.

### DIFF
--- a/src/Plugin/facets/processor/DateStatusProcessor.php
+++ b/src/Plugin/facets/processor/DateStatusProcessor.php
@@ -112,8 +112,13 @@ class DateStatusProcessor extends DefaultStatusProcessorBase implements PreQuery
    * {@inheritdoc}
    */
   public function supportsFacet(FacetInterface $facet) {
+    $supported_types = [
+      "field_item:daterange",
+      "field_item:datetime",
+      "datetime_iso8601",
+    ];
     $data_definition = $facet->getDataDefinition();
-    if ($data_definition->getDataType() == "field_item:daterange") {
+    if (in_array($data_definition->getDataType(), $supported_types)) {
       return TRUE;
     }
     if (!($data_definition instanceof ComplexDataDefinitionInterface)) {
@@ -122,7 +127,7 @@ class DateStatusProcessor extends DefaultStatusProcessorBase implements PreQuery
 
     $property_definitions = $data_definition->getPropertyDefinitions();
     foreach ($property_definitions as $definition) {
-      if ($definition->getDataType() == "field_item:daterange") {
+      if (in_array($definition->getDataType(), $supported_types)) {
         return TRUE;
       }
     }

--- a/src/Plugin/facets/processor/DateUrlProcessor.php
+++ b/src/Plugin/facets/processor/DateUrlProcessor.php
@@ -80,8 +80,13 @@ class DateUrlProcessor extends UrlProcessorHandler {
    * {@inheritdoc}
    */
   public function supportsFacet(FacetInterface $facet) {
+    $supported_types = [
+      "field_item:daterange",
+      "field_item:datetime",
+      "datetime_iso8601",
+    ];
     $data_definition = $facet->getDataDefinition();
-    if ($data_definition->getDataType() == "field_item:daterange") {
+    if (in_array($data_definition->getDataType(), $supported_types)) {
       return TRUE;
     }
     if (!($data_definition instanceof ComplexDataDefinitionInterface)) {
@@ -90,7 +95,7 @@ class DateUrlProcessor extends UrlProcessorHandler {
 
     $property_definitions = $data_definition->getPropertyDefinitions();
     foreach ($property_definitions as $definition) {
-      if ($definition->getDataType() == "field_item:daterange") {
+      if (in_array($definition->getDataType(), $supported_types)) {
         return TRUE;
       }
     }

--- a/src/Plugin/facets/query_type/DateStatus.php
+++ b/src/Plugin/facets/query_type/DateStatus.php
@@ -166,7 +166,7 @@ class DateStatus extends QueryTypePluginBase implements ContainerFactoryPluginIn
     $sorts = &$query->getSorts();
     if (count($active_items) > 1) {
       // In case we have both options selected, we sort ASC.
-      $sorts[$field_name] = 'ASC';
+      $sorts[$field_name] = 'DESC';
       return;
     }
 

--- a/src/Plugin/facets/query_type/DateStatus.php
+++ b/src/Plugin/facets/query_type/DateStatus.php
@@ -165,7 +165,7 @@ class DateStatus extends QueryTypePluginBase implements ContainerFactoryPluginIn
   protected function applySort(QueryInterface $query, array $active_items, string $field_name): void {
     $sorts = &$query->getSorts();
     if (count($active_items) > 1) {
-      // In case we have both options selected, we sort ASC.
+      // In case we have both options selected, we sort DESC.
       $sorts[$field_name] = 'DESC';
       return;
     }

--- a/tests/src/Kernel/DateStatusTest.php
+++ b/tests/src/Kernel/DateStatusTest.php
@@ -138,10 +138,10 @@ class DateStatusTest extends ListsSourceBaseTest {
     $results = $query->getResults();
     $this->assertCount(4, $results->getResultItems());
     $this->assertSort($results->getResultItems(), [
-      'oldest',
-      'old',
-      'tomorrow',
       'future',
+      'tomorrow',
+      'old',
+      'oldest',
     ]);
   }
 


### PR DESCRIPTION
## OPENEUROPA-310

### Description

Extend the types of fields that can use the status and url processors.

### Change log

- Added:
- Changed: Extend the types of fields that can use the status and url processors.

- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

