### PR TITLE
OPENEUROPA-3275: Use correct string for translations.

### DIFF
--- a/translations/oe_list_pages-bg.po
+++ b/translations/oe_list_pages-bg.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Показване на резултати от @start до @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-cs.po
+++ b/translations/oe_list_pages-cs.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Zobrazený počet výsledků vyhledávání: @start až @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-da.po
+++ b/translations/oe_list_pages-da.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Viser resultaterne @start til @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-de.po
+++ b/translations/oe_list_pages-de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Treffer @start bis @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-el.po
+++ b/translations/oe_list_pages-el.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Εμφάνιση αποτελεσμάτων @start έως @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-es.po
+++ b/translations/oe_list_pages-es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Mostrando resultados @start a @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-et.po
+++ b/translations/oe_list_pages-et.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Tulemused @start kuni @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-fi.po
+++ b/translations/oe_list_pages-fi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Näytetään tulokset @start – @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-fr.po
+++ b/translations/oe_list_pages-fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Résultats @start sur @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-ga.po
+++ b/translations/oe_list_pages-ga.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Torthaí ó @start go @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-hr.po
+++ b/translations/oe_list_pages-hr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Rezultati @start do @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-hu.po
+++ b/translations/oe_list_pages-hu.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Megjelenített eredmények: @start–@end."
 
 msgid "Next"

--- a/translations/oe_list_pages-it.po
+++ b/translations/oe_list_pages-it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Risultati da @start a @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-lt.po
+++ b/translations/oe_list_pages-lt.po
@@ -1,7 +1,7 @@
   msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Rodomi rezultatai: @start iš @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-lv.po
+++ b/translations/oe_list_pages-lv.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Tiek rādīts(i) @start līdz @end rezultāti"
 
 msgid "Next"

--- a/translations/oe_list_pages-mt.po
+++ b/translations/oe_list_pages-mt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Qed jintwerew ir-riżultati @start sa @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-nl.po
+++ b/translations/oe_list_pages-nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Resultaten @start tot en met @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-pl.po
+++ b/translations/oe_list_pages-pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Wyświetlają się wyniki od @start do @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-pt-pt.po
+++ b/translations/oe_list_pages-pt-pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Resultados @start até @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-ro.po
+++ b/translations/oe_list_pages-ro.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Se afișează rezultatele de la @start la @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-sk.po
+++ b/translations/oe_list_pages-sk.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Zobrazujú sa výsledky @start až @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-sl.po
+++ b/translations/oe_list_pages-sl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Prikazani rezultati @start do @end"
 
 msgid "Next"

--- a/translations/oe_list_pages-sv.po
+++ b/translations/oe_list_pages-sv.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-msgid "Showing results @start to @end"
+msgid "Showing results @first to @last"
 msgstr "Visar resultat @start–@end"
 
 msgid "Next"


### PR DESCRIPTION
## OPENEUROPA-3275

### Description

Use correct string for translations.
### Change log

- Added:
- Changed: Use correct string for translations.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

