### PR TITLE
EWPP-332: Exposed filters show checked the default filters from the bundle when overriding

### DIFF
--- a/src/Plugin/EntityMetaRelation/ListPage.php
+++ b/src/Plugin/EntityMetaRelation/ListPage.php
@@ -284,8 +284,10 @@ class ListPage extends EntityMetaRelationContentFormPluginBase {
     ], []));
 
     $override = $form_state->getValue('exposed_filters_wrapper')['exposed_filters_override'];
-    $entity_meta_wrapper->setConfiguration(['override_exposed_filters' => $override]);
-    $entity_meta_wrapper->setConfiguration(['exposed_filters' => $selected_filters] + $entity_meta_wrapper->getConfiguration());
+    $configuration = $entity_meta_wrapper->getConfiguration();
+    $configuration['override_exposed_filters'] = $override;
+    $configuration['exposed_filters'] = $override ? $selected_filters : [];
+    $entity_meta_wrapper->setConfiguration($configuration);
     $host_entity->get('emr_entity_metas')->attach($entity_meta);
   }
 

--- a/src/Plugin/EntityMetaRelation/ListPage.php
+++ b/src/Plugin/EntityMetaRelation/ListPage.php
@@ -134,10 +134,6 @@ class ListPage extends EntityMetaRelationContentFormPluginBase {
           $option,
           '#value',
         ]), 0);
-        NestedArray::setValue($form, array_merge($parents, [
-          $option,
-          '#checked',
-        ]), FALSE);
       }
     }
     return $form[$key];
@@ -247,6 +243,10 @@ class ListPage extends EntityMetaRelationContentFormPluginBase {
         '#description' => $this->t('Configure which exposed filters should show up on this page.'),
         '#default_value' => $overridden,
       ];
+
+      $input = $form_state->getUserInput();
+      $input['exposed_filters_wrapper']['exposed_filters'] = $configuration;
+      $form_state->setUserInput($input);
 
       $form[$key]['bundle_wrapper']['exposed_filters_wrapper']['exposed_filters'] = [
         '#type' => 'checkboxes',

--- a/tests/src/FunctionalJavascript/ListPagesExposedFiltersTest.php
+++ b/tests/src/FunctionalJavascript/ListPagesExposedFiltersTest.php
@@ -72,8 +72,13 @@ class ListPagesExposedFiltersTest extends WebDriverTestBase {
     $page->selectFieldOption('Source bundle', 'Content type one');
     $this->assertSession()->assertWaitOnAjaxRequest();
     $page->checkField('Override default exposed filters');
+    // By default, the CT exposed filters are Body and Status.
+    $this->assertSession()->checkboxChecked('Published');
+    $this->assertSession()->checkboxChecked('Body');
+    $this->assertSession()->checkboxNotChecked('Select one');
+    $this->assertSession()->checkboxNotChecked('Created');
+    $page->uncheckField('Body');
     $page->checkField('Select one');
-    $page->checkField('Published');
     $page->fillField('Title', 'Node title');
 
     $page->pressButton('Save');

--- a/tests/src/FunctionalJavascript/ListPagesExposedFiltersTest.php
+++ b/tests/src/FunctionalJavascript/ListPagesExposedFiltersTest.php
@@ -164,8 +164,21 @@ class ListPagesExposedFiltersTest extends WebDriverTestBase {
     $this->assertFieldChecked('Override default exposed filters');
     $this->assertFieldChecked('Select two');
     $this->assertFieldChecked('Facet for status');
+    // Switch to other ct and check overriden is maintained.
+    $page->selectFieldOption('Source bundle', 'Content type one');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->checkboxChecked('Published');
+    $this->assertSession()->checkboxChecked('Body');
+    $this->assertSession()->checkboxNotChecked('Select one');
+    $this->assertSession()->checkboxNotChecked('Created');
+    // Switch back.
+    $page->selectFieldOption('Source bundle', 'Content type two');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertFieldChecked('Select two');
+    $this->assertFieldChecked('Facet for status');
     $page->uncheckField('Override default exposed filters');
     $page->pressButton('Save');
+
     \Drupal::entityTypeManager()->getStorage('entity_meta_relation')->resetCache();
     $node = $this->drupalGetNodeByTitle('Node title', TRUE);
     /** @var \Drupal\emr\Field\ComputedEntityMetasItemList $entity_meta_list */

--- a/tests/src/FunctionalJavascript/ListPagesExposedFiltersTest.php
+++ b/tests/src/FunctionalJavascript/ListPagesExposedFiltersTest.php
@@ -132,12 +132,33 @@ class ListPagesExposedFiltersTest extends WebDriverTestBase {
     $this->assertEquals(TRUE, $actual_override_exposed_filters);
     $this->assertEquals([], $actual_exposed_filters);
 
+    // Add back some overridden exposed filters so that we can remove them all
+    // at once.
+    $this->drupalGet($node->toUrl('edit-form'));
+    $this->clickLink('List Page');
+    $page->checkField('Select two');
+    $page->checkField('Facet for status');
+    $page->pressButton('Save');
+    \Drupal::entityTypeManager()->getStorage('entity_meta_relation')->resetCache();
+    $node = $this->drupalGetNodeByTitle('Node title', TRUE);
+    /** @var \Drupal\emr\Field\ComputedEntityMetasItemList $entity_meta_list */
+    $entity_meta_list = $node->get('emr_entity_metas');
+    $entity_meta = $entity_meta_list->getEntityMeta('oe_list_page');
+    $entity_meta_wrapper = $entity_meta->getWrapper();
+    $actual_exposed_filters = $entity_meta_wrapper->getConfiguration()['exposed_filters'];
+    $actual_override_exposed_filters = $entity_meta_wrapper->getConfiguration()['override_exposed_filters'];
+    $this->assertEquals(TRUE, $actual_override_exposed_filters);
+    $this->assertEquals([
+      'list_facet_source_node_content_type_twofield_select_two' => 'list_facet_source_node_content_type_twofield_select_two',
+      'list_facet_source_node_content_type_twostatus' => 'list_facet_source_node_content_type_twostatus',
+    ], $actual_exposed_filters);
+
     // Disable the overridden exposed filters to return back to the defaults.
     $this->drupalGet($node->toUrl('edit-form'));
     $this->clickLink('List Page');
     $this->assertFieldChecked('Override default exposed filters');
-    $this->assertNoFieldChecked('Select two');
-    $this->assertNoFieldChecked('Facet for status');
+    $this->assertFieldChecked('Select two');
+    $this->assertFieldChecked('Facet for status');
     $page->uncheckField('Override default exposed filters');
     $page->pressButton('Save');
     \Drupal::entityTypeManager()->getStorage('entity_meta_relation')->resetCache();

--- a/tests/src/FunctionalJavascript/ListPagesFiltersTest.php
+++ b/tests/src/FunctionalJavascript/ListPagesFiltersTest.php
@@ -68,6 +68,8 @@ class ListPagesFiltersTest extends WebDriverTestBase {
     $page->selectFieldOption('Source bundle', 'Content type one');
     $this->assertSession()->assertWaitOnAjaxRequest();
     $page->checkField('Override default exposed filters');
+    $page->uncheckField('Body');
+    $page->uncheckField('Published');
     $page->fillField('Title', 'Another List page for ct1');
     $page->pressButton('Save');
 


### PR DESCRIPTION
* [x] Fixed removal of overrides by unchecking the box
* [x] Defaulting to the default exposed filters when trying to override them in the form