### PR TITLE
EWPP-266: Use correct string placeholders on translations.

### DIFF
--- a/translations/oe_list_pages-bg.po
+++ b/translations/oe_list_pages-bg.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Показване на резултати от @start до @end"
+msgstr "Показване на резултати от @first до @last"
 
 msgid "Next"
 msgstr "Следваща"

--- a/translations/oe_list_pages-cs.po
+++ b/translations/oe_list_pages-cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Zobrazený počet výsledků vyhledávání: @start až @end"
+msgstr "Zobrazený počet výsledků vyhledávání: @first až @last"
 
 msgid "Next"
 msgstr "Následující"

--- a/translations/oe_list_pages-da.po
+++ b/translations/oe_list_pages-da.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Viser resultaterne @start til @end"
+msgstr "Viser resultaterne @first til @last"
 
 msgid "Next"
 msgstr "Næste"

--- a/translations/oe_list_pages-de.po
+++ b/translations/oe_list_pages-de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Treffer @start bis @end"
+msgstr "Treffer @first bis @last"
 
 msgid "Next"
 msgstr "Nächste Seite"

--- a/translations/oe_list_pages-el.po
+++ b/translations/oe_list_pages-el.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Εμφάνιση αποτελεσμάτων @start έως @end"
+msgstr "Εμφάνιση αποτελεσμάτων @first έως @last"
 
 msgid "Next"
 msgstr "Επόμενη"

--- a/translations/oe_list_pages-es.po
+++ b/translations/oe_list_pages-es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Mostrando resultados @start a @end"
+msgstr "Mostrando resultados @first a @last"
 
 msgid "Next"
 msgstr "Siguiente"

--- a/translations/oe_list_pages-et.po
+++ b/translations/oe_list_pages-et.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Tulemused @start kuni @end"
+msgstr "Tulemused @first kuni @last"
 
 msgid "Next"
 msgstr "Järgmine"

--- a/translations/oe_list_pages-fi.po
+++ b/translations/oe_list_pages-fi.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Näytetään tulokset @start – @end"
+msgstr "Näytetään tulokset @first – @last"
 
 msgid "Next"
 msgstr "Seuraava"

--- a/translations/oe_list_pages-fr.po
+++ b/translations/oe_list_pages-fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Résultats @start sur @end"
+msgstr "Résultats @first sur @last"
 
 msgid "Next"
 msgstr "Suivant"

--- a/translations/oe_list_pages-ga.po
+++ b/translations/oe_list_pages-ga.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Torthaí ó @start go @end"
+msgstr "Torthaí ó @first go @last"
 
 msgid "Next"
 msgstr "Ar aghaidh"

--- a/translations/oe_list_pages-hr.po
+++ b/translations/oe_list_pages-hr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Rezultati @start do @end"
+msgstr "Rezultati @first do @last"
 
 msgid "Next"
 msgstr "Sljedeća"

--- a/translations/oe_list_pages-hu.po
+++ b/translations/oe_list_pages-hu.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Megjelenített eredmények: @start–@end."
+msgstr "Megjelenített eredmények: @first–@last."
 
 msgid "Next"
 msgstr "Következő"

--- a/translations/oe_list_pages-it.po
+++ b/translations/oe_list_pages-it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Risultati da @start a @end"
+msgstr "Risultati da @first a @last"
 
 msgid "Next"
 msgstr "Seguente"

--- a/translations/oe_list_pages-lt.po
+++ b/translations/oe_list_pages-lt.po
@@ -2,7 +2,7 @@
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Rodomi rezultatai: @start iš @end"
+msgstr "Rodomi rezultatai: @first iš @last"
 
 msgid "Next"
 msgstr "Kitas"

--- a/translations/oe_list_pages-lv.po
+++ b/translations/oe_list_pages-lv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Tiek rādīts(i) @start līdz @end rezultāti"
+msgstr "Tiek rādīts(i) @first līdz @last rezultāti"
 
 msgid "Next"
 msgstr "Nākamā"

--- a/translations/oe_list_pages-mt.po
+++ b/translations/oe_list_pages-mt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Qed jintwerew ir-riżultati @start sa @end"
+msgstr "Qed jintwerew ir-riżultati @first sa @last"
 
 msgid "Next"
 msgstr "Li Jmiss"

--- a/translations/oe_list_pages-nl.po
+++ b/translations/oe_list_pages-nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Resultaten @start tot en met @end"
+msgstr "Resultaten @first tot en met @last"
 
 msgid "Next"
 msgstr "Volgende"

--- a/translations/oe_list_pages-pl.po
+++ b/translations/oe_list_pages-pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Wyświetlają się wyniki od @start do @end"
+msgstr "Wyświetlają się wyniki od @first do @last"
 
 msgid "Next"
 msgstr "Następna"

--- a/translations/oe_list_pages-pt-pt.po
+++ b/translations/oe_list_pages-pt-pt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Resultados @start até @end"
+msgstr "Resultados @first até @last"
 
 msgid "Next"
 msgstr "Seguinte"

--- a/translations/oe_list_pages-ro.po
+++ b/translations/oe_list_pages-ro.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Se afișează rezultatele de la @start la @end"
+msgstr "Se afișează rezultatele de la @first la @last"
 
 msgid "Next"
 msgstr "Următor"

--- a/translations/oe_list_pages-sk.po
+++ b/translations/oe_list_pages-sk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Zobrazujú sa výsledky @start až @end"
+msgstr "Zobrazujú sa výsledky @first až @last"
 
 msgid "Next"
 msgstr "Nasledujúca"

--- a/translations/oe_list_pages-sl.po
+++ b/translations/oe_list_pages-sl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Prikazani rezultati @start do @end"
+msgstr "Prikazani rezultati @first do @last"
 
 msgid "Next"
 msgstr "Naslednja"

--- a/translations/oe_list_pages-sv.po
+++ b/translations/oe_list_pages-sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 
 msgid "Showing results @first to @last"
-msgstr "Visar resultat @start–@end"
+msgstr "Visar resultat @first–@last"
 
 msgid "Next"
 msgstr "Nästa"


### PR DESCRIPTION
## EWPP-266
### Description

Use correct string placeholders on translations.

### Change log

- Added:
- Changed: Use correct string placeholders on translations.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

