### PR TITLE
EWPP-453: Execute and render the RSS list

### DIFF
--- a/oe_list_pages.module
+++ b/oe_list_pages.module
@@ -45,6 +45,7 @@ function oe_list_pages_theme($existing, $type, $theme, $path) {
       'variables' => [
         'title' => '',
         'link' => '',
+        'guid' => '',
         'description' => '',
         'item_elements' => [],
       ],

--- a/oe_list_pages.module
+++ b/oe_list_pages.module
@@ -33,7 +33,7 @@ function oe_list_pages_theme($existing, $type, $theme, $path) {
       'variables' => [
         'title' => '',
         'link' => '',
-        'description' => '',
+        'channel_description' => '',
         'language' => '',
         'copyright' => '',
         'image' => [],
@@ -46,7 +46,7 @@ function oe_list_pages_theme($existing, $type, $theme, $path) {
         'title' => '',
         'link' => '',
         'guid' => '',
-        'description' => '',
+        'item_description' => '',
         'item_elements' => [],
       ],
     ],

--- a/oe_list_pages.module
+++ b/oe_list_pages.module
@@ -41,6 +41,14 @@ function oe_list_pages_theme($existing, $type, $theme, $path) {
         'items' => [],
       ],
     ],
+    'oe_list_pages_rss_item' => [
+      'variables' => [
+        'title' => '',
+        'link' => '',
+        'description' => '',
+        'item_elements' => [],
+      ],
+    ],
   ];
 }
 

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -210,6 +210,7 @@ class ListPageRssController extends ControllerBase {
         '#theme' => 'oe_list_pages_rss_item',
         '#title' => $entity->label(),
         '#link' => $entity->toUrl('canonical', ['absolute' => TRUE]),
+        '#guid' => $entity->toUrl('canonical', ['absolute' => TRUE]),
         '#description' => '',
         '#item_elements' => [
           [

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -204,6 +204,8 @@ class ListPageRssController extends ControllerBase {
       'name' => 'changed',
       'direction' => 'DESC',
     ]);
+    // Always limit the rss to the last 25 results.
+    $configuration->setLimit(25);
     $execution_result = $this->listExecutionManager->executeList($configuration);
     $query = $execution_result->getQuery();
     $results = $execution_result->getResults();

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_list_pages\Controller;
 
+use DateTimeInterface;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
@@ -11,6 +12,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Render\RendererInterface;
@@ -19,6 +21,7 @@ use Drupal\Core\Url;
 use Drupal\emr\Entity\EntityMetaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\oe_list_pages\ListBuilderInterface;
+use Drupal\oe_list_pages\ListExecutionManagerInterface;
 use Drupal\oe_list_pages\ListPageRssAlterEvent;
 use Drupal\oe_list_pages\ListPageEvents;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -38,6 +41,13 @@ class ListPageRssController extends ControllerBase {
   protected $configFactory;
 
   /**
+   * The date formatter.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -50,6 +60,13 @@ class ListPageRssController extends ControllerBase {
    * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
    */
   protected $eventDispatcher;
+
+  /**
+   * The list execution manager.
+   *
+   * @var \Drupal\oe_list_pages\ListExecutionManagerInterface
+   */
+  protected $listExecutionManager;
 
   /**
    * The list builder.
@@ -77,21 +94,27 @@ class ListPageRssController extends ControllerBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The entity type manager.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   The event dispatcher.
    * @param \Drupal\oe_list_pages\ListBuilderInterface $list_builder
    *   The list builder.
+   * @param \Drupal\oe_list_pages\ListExecutionManagerInterface $list_execution_manager
+   *   The list execution manager.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The event dispatcher.
    * @param \Drupal\Core\Theme\ThemeManagerInterface $theme_manager
    *   The theme manager.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, EventDispatcherInterface $event_dispatcher, ListBuilderInterface $list_builder, RendererInterface $renderer, ThemeManagerInterface $theme_manager) {
+  public function __construct(ConfigFactoryInterface $config_factory, DateFormatterInterface $date_formatter, EntityTypeManagerInterface $entity_type_manager, EventDispatcherInterface $event_dispatcher, ListBuilderInterface $list_builder, ListExecutionManagerInterface $list_execution_manager, RendererInterface $renderer, ThemeManagerInterface $theme_manager) {
     $this->configFactory = $config_factory;
+    $this->dateFormatter = $date_formatter;
     $this->entityTypeManager = $entity_type_manager;
     $this->eventDispatcher = $event_dispatcher;
+    $this->listExecutionManager = $list_execution_manager;
     $this->listBuilder = $list_builder;
     $this->renderer = $renderer;
     $this->themeManager = $theme_manager;
@@ -103,9 +126,11 @@ class ListPageRssController extends ControllerBase {
   public static function create(ContainerInterface $container): ListPageRssController {
     return new static(
       $container->get('config.factory'),
+      $container->get('date.formatter'),
       $container->get('entity_type.manager'),
       $container->get('event_dispatcher'),
       $container->get('oe_list_pages.builder'),
+      $container->get('oe_list_pages.execution_manager'),
       $container->get('renderer'),
       $container->get('theme.manager')
     );
@@ -134,7 +159,8 @@ class ListPageRssController extends ControllerBase {
       '#copyright' => $this->getChannelCopyright(),
       '#image' => $this->getChannelImage($cache_metadata),
       '#channel_elements' => [],
-      '#items' => $this->getItemList($node),
+      '#items' => $this->getItemList($node, $cache_metadata),
+      '#list_page' => $node,
     ];
     $cache_metadata->addCacheableDependency($default_link);
     $cache_metadata->applyTo($build);
@@ -164,12 +190,37 @@ class ListPageRssController extends ControllerBase {
    *
    * @param \Drupal\node\NodeInterface $node
    *   The node containing the list.
+   * @param \Drupal\Core\Cache\CacheableMetadata $cache_metadata
+   *   The current cache metadata.
    *
    * @return array
    *   Array of items to be rendered.
    */
-  protected function getItemList(NodeInterface $node): array {
-    return [];
+  protected function getItemList(NodeInterface $node, CacheableMetadata $cache_metadata): array {
+    $execution_result = $this->listExecutionManager->executeList($node);
+    $results = $execution_result->getResults();
+    $result_items = [];
+    foreach ($results->getResultItems() as $item) {
+      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = $item->getOriginalObject()->getEntity();
+      $cache_metadata->addCacheableDependency($entity);
+      $creation_date = $entity->get('changed')->value;
+      $result_items[] = [
+        '#theme' => 'oe_list_pages_rss_item',
+        '#title' => $entity->label(),
+        '#link' => $entity->toUrl('canonical', ['absolute' => TRUE]),
+        '#description' => '',
+        '#item_elements' => [
+          [
+            'key' => 'pubDate',
+            'value' => $this->dateFormatter->format($creation_date, 'custom', DateTimeInterface::RFC822),
+            'attributes' => '',
+          ],
+        ],
+        '#entity' => $entity,
+      ];
+    }
+    return $result_items;
   }
 
   /**

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -22,6 +22,7 @@ use Drupal\emr\Entity\EntityMetaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\oe_list_pages\ListBuilderInterface;
 use Drupal\oe_list_pages\ListExecutionManagerInterface;
+use Drupal\oe_list_pages\ListPageConfiguration;
 use Drupal\oe_list_pages\ListPageRssAlterEvent;
 use Drupal\oe_list_pages\ListPageEvents;
 use Drupal\oe_list_pages\ListPageRssItemAlterEvent;
@@ -197,7 +198,8 @@ class ListPageRssController extends ControllerBase {
    *   Array of items to be rendered.
    */
   protected function getItemList(NodeInterface $node, CacheableMetadata $cache_metadata): array {
-    $execution_result = $this->listExecutionManager->executeList($node);
+    $configuration = ListPageConfiguration::fromEntity($node);
+    $execution_result = $this->listExecutionManager->executeList($configuration);
     $query = $execution_result->getQuery();
     $results = $execution_result->getResults();
     $cache_metadata->addCacheableDependency($query);

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -200,6 +200,11 @@ class ListPageRssController extends ControllerBase {
    */
   protected function getItemList(NodeInterface $node, CacheableMetadata $cache_metadata): array {
     $configuration = ListPageConfiguration::fromEntity($node);
+    // Always sort by the updated date descending.
+    $configuration->setSort([
+      'name' => 'changed',
+      'direction' => 'DESC',
+    ]);
     $execution_result = $this->listExecutionManager->executeList($configuration);
     $query = $execution_result->getQuery();
     $results = $execution_result->getResults();

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -217,9 +217,9 @@ class ListPageRssController extends ControllerBase {
         '#description' => '',
         '#item_elements' => [
           [
-            'key' => 'pubDate',
-            'value' => $this->dateFormatter->format($creation_date, 'custom', DateTimeInterface::RFC822),
-            'attributes' => '',
+            '#type' => 'html_tag',
+            '#tag' => 'pubDate',
+            '#value' => $this->dateFormatter->format($creation_date, 'custom', DateTimeInterface::RFC822),
           ],
         ],
       ];

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -6,6 +6,7 @@ namespace Drupal\oe_list_pages\Controller;
 
 use DateTimeInterface;
 use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Cache\CacheableMetadata;
@@ -211,12 +212,21 @@ class ListPageRssController extends ControllerBase {
       $entity = $item->getOriginalObject()->getEntity();
       $cache_metadata->addCacheableDependency($entity);
       $creation_date = $entity->get('changed')->value;
+      if ($entity->hasField('body')) {
+        $description = $entity->body->view([
+          'type' => 'text_default',
+          'label' => 'hidden',
+          'settings' => [],
+        ]);
+        $description = Html::escape($this->renderer->renderPlain($description[0]));
+      }
+      $description = $description ?? '';
       $result_item = [
         '#theme' => 'oe_list_pages_rss_item',
         '#title' => $entity->label(),
         '#link' => $entity->toUrl('canonical', ['absolute' => TRUE]),
         '#guid' => $entity->toUrl('canonical', ['absolute' => TRUE]),
-        '#description' => '',
+        '#description' => $description,
         '#item_elements' => [
           [
             '#type' => 'html_tag',

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -6,7 +6,6 @@ namespace Drupal\oe_list_pages\Controller;
 
 use DateTimeInterface;
 use Drupal\Component\Render\FormattableMarkup;
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Cache\CacheableMetadata;
@@ -157,7 +156,7 @@ class ListPageRssController extends ControllerBase {
       '#theme' => 'oe_list_pages_rss',
       '#title' => $default_title,
       '#link' => $default_link->getGeneratedUrl(),
-      '#description' => $this->getChannelDescription($node, $cache_metadata),
+      '#channel_description' => $this->getChannelDescription($node, $cache_metadata),
       '#language' => $node->language()->getId(),
       '#copyright' => $this->getChannelCopyright(),
       '#image' => $this->getChannelImage($cache_metadata),
@@ -226,14 +225,14 @@ class ListPageRssController extends ControllerBase {
         // We need to escape the results of renderPlain in order to maintain
         // all tags added by the renderer. If we don't do it, things like p tags
         // and linebreaks will be lost after they go through the twig template.
-        $description = Html::escape($this->renderer->renderPlain($description[0]));
+        $description = $this->renderer->renderPlain($description[0]);
       }
       $result_item = [
         '#theme' => 'oe_list_pages_rss_item',
         '#title' => $entity->label(),
         '#link' => $entity->toUrl('canonical', ['absolute' => TRUE]),
         '#guid' => $entity->toUrl('canonical', ['absolute' => TRUE]),
-        '#description' => $description,
+        '#item_description' => (string) $description,
         '#item_elements' => [],
       ];
 

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -161,7 +161,6 @@ class ListPageRssController extends ControllerBase {
       '#image' => $this->getChannelImage($cache_metadata),
       '#channel_elements' => [],
       '#items' => $this->getItemList($node, $cache_metadata),
-      '#list_page' => $node,
     ];
     $cache_metadata->addCacheableDependency($default_link);
     $cache_metadata->applyTo($build);
@@ -199,7 +198,11 @@ class ListPageRssController extends ControllerBase {
    */
   protected function getItemList(NodeInterface $node, CacheableMetadata $cache_metadata): array {
     $execution_result = $this->listExecutionManager->executeList($node);
+    $query = $execution_result->getQuery();
     $results = $execution_result->getResults();
+    $cache_metadata->addCacheableDependency($query);
+    $cache_metadata->addCacheableDependency($results);
+    $cache_metadata->addCacheTags(['search_api_list:' . $query->getIndex()->id()]);
     $result_items = [];
     foreach ($results->getResultItems() as $item) {
       /** @var \Drupal\Core\Entity\EntityInterface $entity */
@@ -219,7 +222,6 @@ class ListPageRssController extends ControllerBase {
             'attributes' => '',
           ],
         ],
-        '#entity' => $entity,
       ];
 
       // Dispatch event to allow to alter the item build before being rendered.

--- a/src/Controller/ListPageRssController.php
+++ b/src/Controller/ListPageRssController.php
@@ -205,7 +205,7 @@ class ListPageRssController extends ControllerBase {
     $cache_metadata->addCacheTags(['search_api_list:' . $query->getIndex()->id()]);
     $result_items = [];
     foreach ($results->getResultItems() as $item) {
-      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
       $entity = $item->getOriginalObject()->getEntity();
       $cache_metadata->addCacheableDependency($entity);
       $creation_date = $entity->get('changed')->value;

--- a/src/ListExecutionManager.php
+++ b/src/ListExecutionManager.php
@@ -84,14 +84,19 @@ class ListExecutionManager implements ListExecutionManagerInterface {
     }
 
     // Determine the query options and execute it.
-    $bundle_entity_type = $this->entityTypeManager->getDefinition($configuration->getEntityType())->getBundleEntityType();
-    $storage = $this->entityTypeManager->getStorage($bundle_entity_type);
-    $bundle = $storage->load($configuration->getBundle());
-    $sort = $bundle->getThirdPartySetting('oe_list_pages', 'default_sort', []);
     $current_page = (int) $this->requestStack->getCurrentRequest()->get('page', 0);
-    $sort = $sort ? [$sort['name'] => $sort['direction']] : [];
     $language = $this->languageManager->getCurrentLanguage()->getId();
     $preset_filters = $configuration->getDefaultFiltersValues();
+    // If there is a sort configured use it,
+    // otherwise use the bundle's default sort if set.
+    $sort = $configuration->getSort();
+    if (!$sort) {
+      $bundle_entity_type = $this->entityTypeManager->getDefinition($configuration->getEntityType())->getBundleEntityType();
+      $storage = $this->entityTypeManager->getStorage($bundle_entity_type);
+      $bundle = $storage->load($configuration->getBundle());
+      $sort = $bundle->getThirdPartySetting('oe_list_pages', 'default_sort', []);
+    }
+    $sort = $sort ? [$sort['name'] => $sort['direction']] : [];
 
     $options = [
       'limit' => $limit,

--- a/src/ListPageConfiguration.php
+++ b/src/ListPageConfiguration.php
@@ -68,6 +68,15 @@ class ListPageConfiguration {
   protected $limit = NULL;
 
   /**
+   * The sorting type for the query.
+   *
+   * The sort should an array with two values keyed 'name' and 'direction'.
+   *
+   * @var array
+   */
+  protected $sort = [];
+
+  /**
    * ListPageConfiguration constructor.
    *
    * @param array $configuration
@@ -103,6 +112,7 @@ class ListPageConfiguration {
       'default_filter_values' => $wrapper_configuration['preset_filters'] ?? [],
       'exposed_filters_overridden' => isset($wrapper_configuration['override_exposed_filters']) ? (bool) $wrapper_configuration['override_exposed_filters'] : FALSE,
       'limit' => $wrapper_configuration['limit'] ?? NULL,
+      'sort' => [],
     ];
 
     return new static($configuration);
@@ -249,6 +259,26 @@ class ListPageConfiguration {
   }
 
   /**
+   * Returns the sort.
+   *
+   * @return array
+   *   The sort.
+   */
+  public function getSort(): array {
+    return $this->sort;
+  }
+
+  /**
+   * Sets the sort.
+   *
+   * @param array $sort
+   *   The sort.
+   */
+  public function setSort(array $sort): void {
+    $this->sort = $sort;
+  }
+
+  /**
    * Returns an ID for the configuration.
    *
    * Calculates a hash based on the configuration values so it can be used
@@ -274,6 +304,7 @@ class ListPageConfiguration {
       'exposed_filters_overridden' => $this->isExposedFiltersOverridden(),
       'exposed_filters' => $this->getExposedFilters(),
       'default_filter_values' => $this->getDefaultFiltersValues(),
+      'sort' => $this->getSort(),
     ];
   }
 

--- a/src/ListPageEvents.php
+++ b/src/ListPageEvents.php
@@ -24,10 +24,17 @@ final class ListPageEvents {
   const ALTER_BUNDLES = 'oe_list_pages.bundles_alter';
 
   /**
-   * Event fired when the RSS build before its rendered.
+   * Event fired after the RSS is built and before its rendered.
    *
    * @var string
    */
   const ALTER_RSS_BUILD = "oe_list_pages.rss_build_alter";
+
+  /**
+   * Event fired after the RSS item is built and before its rendered.
+   *
+   * @var string
+   */
+  const ALTER_RSS_ITEM_BUILD = "oe_list_pages.rss_build_item_alter";
 
 }

--- a/src/ListPageEvents.php
+++ b/src/ListPageEvents.php
@@ -31,7 +31,7 @@ final class ListPageEvents {
   const ALTER_RSS_BUILD = "oe_list_pages.rss_build_alter";
 
   /**
-   * Event fired after the RSS item is built and before its rendered.
+   * Event fired after the RSS item is built and before it's rendered.
    *
    * @var string
    */

--- a/src/ListPageEvents.php
+++ b/src/ListPageEvents.php
@@ -24,7 +24,7 @@ final class ListPageEvents {
   const ALTER_BUNDLES = 'oe_list_pages.bundles_alter';
 
   /**
-   * Event fired after the RSS is built and before its rendered.
+   * Event fired after the RSS is built and before it's rendered.
    *
    * @var string
    */

--- a/src/ListPageRssItemAlterEvent.php
+++ b/src/ListPageRssItemAlterEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_list_pages;
+
+use Drupal\Core\Entity\EntityInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event thrown in order to alter an RSS item build before its rendered.
+ */
+class ListPageRssItemAlterEvent extends Event {
+
+  /**
+   * The render array for an RSS list item.
+   *
+   * @var array
+   */
+  protected $build;
+
+  /**
+   * The entity being rendered as an RSS item.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $entity;
+
+  /**
+   * Constructs the object.
+   *
+   * @param array $build
+   *   The render array for the list page RSS list.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity being rendered.
+   */
+  public function __construct(array $build, EntityInterface $entity) {
+    $this->build = $build;
+    $this->entity = $entity;
+  }
+
+  /**
+   * Returns the build.
+   *
+   * @return array
+   *   The current build.
+   */
+  public function getBuild(): array {
+    return $this->build;
+  }
+
+  /**
+   * Sets the build.
+   *
+   * @param array $build
+   *   The modified build.
+   */
+  public function setBuild(array $build): void {
+    $this->build = $build;
+  }
+
+  /**
+   * Returns the entity item.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The entity being processed.
+   */
+  public function getEntity(): EntityInterface {
+    return $this->entity;
+  }
+
+}

--- a/src/ListPageRssItemAlterEvent.php
+++ b/src/ListPageRssItemAlterEvent.php
@@ -4,11 +4,11 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_list_pages;
 
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Event thrown in order to alter an RSS item build before its rendered.
+ * Event thrown in order to alter an RSS item build before it's rendered.
  */
 class ListPageRssItemAlterEvent extends Event {
 
@@ -22,7 +22,7 @@ class ListPageRssItemAlterEvent extends Event {
   /**
    * The entity being rendered as an RSS item.
    *
-   * @var \Drupal\Core\Entity\EntityInterface
+   * @var \Drupal\Core\Entity\ContentEntityInterface
    */
   protected $entity;
 
@@ -31,10 +31,10 @@ class ListPageRssItemAlterEvent extends Event {
    *
    * @param array $build
    *   The render array for the list page RSS list.
-   * @param \Drupal\Core\Entity\EntityInterface $entity
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity being rendered.
    */
-  public function __construct(array $build, EntityInterface $entity) {
+  public function __construct(array $build, ContentEntityInterface $entity) {
     $this->build = $build;
     $this->entity = $entity;
   }
@@ -62,10 +62,10 @@ class ListPageRssItemAlterEvent extends Event {
   /**
    * Returns the entity item.
    *
-   * @return \Drupal\Core\Entity\EntityInterface
+   * @return \Drupal\Core\Entity\ContentEntityInterface
    *   The entity being processed.
    */
-  public function getEntity(): EntityInterface {
+  public function getEntity(): ContentEntityInterface {
     return $this->entity;
   }
 

--- a/templates/oe-list-pages-rss-item.html.twig
+++ b/templates/oe-list-pages-rss-item.html.twig
@@ -6,6 +6,7 @@
  * Available variables:
  * - title: RSS item title.
  * - link: RSS item link.
+ * - guid: RSS item global unique identifier.
  * - description: RSS body text.
  * - item_elements: RSS item elements to be rendered as XML (pubDate, creator,
  *   guid).
@@ -14,6 +15,7 @@
 <item>
   <title>{{ title }}</title>
   <link>{{ link }}</link>
+  <guid>{{ guid }}</guid>
   <description>{{ description }}</description>
   {% for item in item_elements -%}
     <{{ item.key }}{{ item.attributes -}}

--- a/templates/oe-list-pages-rss-item.html.twig
+++ b/templates/oe-list-pages-rss-item.html.twig
@@ -17,12 +17,5 @@
   <link>{{ link }}</link>
   <guid>{{ guid }}</guid>
   <description>{{ description }}</description>
-  {% for item in item_elements -%}
-    <{{ item.key }}{{ item.attributes -}}
-    {% if item.value -%}
-      >{{ item.value }}</{{ item.key }}>
-    {% else -%}
-      {{ ' />' }}
-    {% endif %}
-  {%- endfor %}
+  {{ item_elements }}
 </item>

--- a/templates/oe-list-pages-rss-item.html.twig
+++ b/templates/oe-list-pages-rss-item.html.twig
@@ -8,8 +8,7 @@
  * - link: RSS item link.
  * - guid: RSS item global unique identifier.
  * - description: RSS body text.
- * - item_elements: RSS item elements to be rendered as XML (pubDate, creator,
- *   guid).
+ * - item_elements: RSS item elements to be rendered as XML (pubDate, creator).
  */
 #}
 <item>

--- a/templates/oe-list-pages-rss-item.html.twig
+++ b/templates/oe-list-pages-rss-item.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display an item in a RSS feed.
+ *
+ * Available variables:
+ * - title: RSS item title.
+ * - link: RSS item link.
+ * - description: RSS body text.
+ * - item_elements: RSS item elements to be rendered as XML (pubDate, creator,
+ *   guid).
+ */
+#}
+<item>
+  <title>{{ title }}</title>
+  <link>{{ link }}</link>
+  <description>{{ description }}</description>
+  {% for item in item_elements -%}
+    <{{ item.key }}{{ item.attributes -}}
+    {% if item.value -%}
+      >{{ item.value }}</{{ item.key }}>
+    {% else -%}
+      {{ ' />' }}
+    {% endif %}
+  {%- endfor %}
+</item>

--- a/templates/oe-list-pages-rss-item.html.twig
+++ b/templates/oe-list-pages-rss-item.html.twig
@@ -7,7 +7,7 @@
  * - title: RSS item title.
  * - link: RSS item link.
  * - guid: RSS item global unique identifier.
- * - description: RSS body text.
+ * - item_description: RSS body text.
  * - item_elements: RSS item elements to be rendered as XML (pubDate, creator).
  */
 #}
@@ -15,6 +15,6 @@
   <title>{{ title }}</title>
   <link>{{ link }}</link>
   <guid>{{ guid }}</guid>
-  <description>{{ description }}</description>
+  <description>{{ item_description }}</description>
   {{ item_elements }}
 </item>

--- a/templates/oe-list-pages-rss.html.twig
+++ b/templates/oe-list-pages-rss.html.twig
@@ -6,7 +6,7 @@
  * Available variables:
  * - link: The link to the feed.
  * - title: The title of the feed.
- * - description: The feed description.
+ * - channel_description: The feed description.
  * - langcode: The language encoding.
  * - copyright: The copyright for the feed.
  * - image: Array with the image information for the feed. It must contain the following keys: url, title and link.
@@ -19,7 +19,7 @@
   <channel>
     <title>{{ title }}</title>
     <link>{{ link }}</link>
-    <description>{{ description }}</description>
+    <description>{{ channel_description }}</description>
     <language>{{ language }}</language>
     <copyright>{{ copyright }}</copyright>
     {% if image is not empty %}

--- a/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
+++ b/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
@@ -7,6 +7,7 @@ namespace Drupal\oe_list_pages_event_subscriber_test\EventSubscriber;
 use Drupal\Core\State\StateInterface;
 use Drupal\oe_list_pages\ListPageRssAlterEvent;
 use Drupal\oe_list_pages\ListPageEvents;
+use Drupal\oe_list_pages\ListPageRssItemAlterEvent;
 use Drupal\oe_list_pages\ListPageSourceAlterEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -40,6 +41,7 @@ class ListPagesTestSubscriber implements EventSubscriberInterface {
       ListPageEvents::ALTER_ENTITY_TYPES => ['onEntityTypesAlter'],
       ListPageEvents::ALTER_BUNDLES => ['onBundlesAlter'],
       ListPageEvents::ALTER_RSS_BUILD => ['onRssBuildAlter'],
+      ListPageEvents::ALTER_RSS_ITEM_BUILD => ['onRssItemBuildAlter'],
     ];
   }
 
@@ -93,6 +95,24 @@ class ListPagesTestSubscriber implements EventSubscriberInterface {
       '#type' => 'html_tag',
       '#tag' => 'custom_tag',
       '#value' => 'custom_value',
+    ];
+    $event->setBuild($build);
+  }
+
+  /**
+   * Event handler for adding channel information.
+   *
+   * @param \Drupal\oe_list_pages\ListPageRssItemAlterEvent $event
+   *   The event object.
+   */
+  public function onRssItemBuildAlter(ListPageRssItemAlterEvent $event): void {
+    $build = $event->getBuild();
+    $entity = $event->getEntity();
+    $creation_date = $entity->get('changed')->value;
+    $build['#item_elements'][] = [
+      'key' => 'creationDate',
+      'attributes' => '',
+      'value' => date('d/m/Y', (int) $creation_date),
     ];
     $event->setBuild($build);
   }

--- a/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
+++ b/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
@@ -108,7 +108,7 @@ class ListPagesTestSubscriber implements EventSubscriberInterface {
   public function onRssItemBuildAlter(ListPageRssItemAlterEvent $event): void {
     $build = $event->getBuild();
     $entity = $event->getEntity();
-    $creation_date = $entity->get('changed')->value;
+    $creation_date = $entity->get('created')->value;
     $build['#item_elements'][] = [
       '#type' => 'html_tag',
       '#tag' => 'creationDate',

--- a/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
+++ b/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
@@ -100,7 +100,7 @@ class ListPagesTestSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Event handler for adding channel information.
+   * Event handler for adding item information.
    *
    * @param \Drupal\oe_list_pages\ListPageRssItemAlterEvent $event
    *   The event object.

--- a/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
+++ b/tests/modules/oe_list_pages_event_subscriber_test/src/EventSubscriber/ListPagesTestSubscriber.php
@@ -110,9 +110,9 @@ class ListPagesTestSubscriber implements EventSubscriberInterface {
     $entity = $event->getEntity();
     $creation_date = $entity->get('changed')->value;
     $build['#item_elements'][] = [
-      'key' => 'creationDate',
-      'attributes' => '',
-      'value' => date('d/m/Y', (int) $creation_date),
+      '#type' => 'html_tag',
+      '#tag' => 'creationDate',
+      '#value' => date('d/m/Y', (int) $creation_date),
     ];
     $event->setBuild($build);
   }

--- a/tests/modules/oe_list_pages_filters_test/config/install/node.type.content_type_one.yml
+++ b/tests/modules/oe_list_pages_filters_test/config/install/node.type.content_type_one.yml
@@ -10,6 +10,9 @@ third_party_settings:
     default_exposed_filters:
       - body
       - list_facet_source_node_content_type_onestatus
+    default_sort:
+      name: created
+      direction: DESC
 description: ''
 help: ''
 new_revision: true

--- a/tests/modules/oe_list_pages_filters_test/config/install/search_api.index.node.yml
+++ b/tests/modules/oe_list_pages_filters_test/config/install/search_api.index.node.yml
@@ -25,6 +25,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.body
+  changed:
+    label: Changed
+    datasource_id: 'entity:node'
+    property_path: changed
+    type: date
+    dependencies:
+      module:
+        - node
   created:
     label: Created
     datasource_id: 'entity:node'
@@ -100,8 +108,10 @@ field_settings:
 datasource_settings:
   'entity:node':
     bundles:
-      default: true
-      selected: {  }
+      default: false
+      selected:
+        - content_type_one
+        - content_type_two
     languages:
       default: true
       selected: {  }

--- a/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
+++ b/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
@@ -90,7 +90,7 @@ class ListPageRssControllerTest extends WebDriverTestBase {
     $this->assertEquals('http://web:8080/build/core/themes/classy/logo.svg', $channel->filterXPath('//image/url')->text());
     $this->assertEquals('European Commission logo', $channel->filterXPath('//image/title')->text());
     $this->assertEquals('http://web:8080/build/', $channel->filterXPath('//image/link')->text());
-    // Assert modules subscribing to the ListPageRssBuildAlterEvent can
+    // Assert modules subscribing to the ListPageRssAlterEvent can
     // alter the build.
     $this->assertEquals('custom_value', $channel->filterXPath('//custom_tag')->text());
 
@@ -101,6 +101,10 @@ class ListPageRssControllerTest extends WebDriverTestBase {
     $this->assertEquals('that yellow fruit', $first_item->filterXpath('//title')->text());
     $this->assertEquals('http://web:8080/build/node/2', $first_item->filterXpath('//link')->text());
     $this->assertEquals('Tue, 20 Oct 20 00:00:00 +1100', $first_item->filterXpath('//pubDate')->text());
+    // Assert modules subscribing to the ListPageRssItemAlterEvent can
+    // alter the item build.
+    $this->assertEquals('20/10/2020', $first_item->filterXpath('//creationDate')->text());
+
     $second_item = $items->eq(1);
     $this->assertEquals('that red fruit', $second_item->filterXpath('//title')->text());
     $this->assertEquals('http://web:8080/build/node/3', $second_item->filterXpath('//link')->text());

--- a/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
+++ b/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
@@ -109,9 +109,13 @@ class ListPageRssControllerTest extends WebDriverTestBase {
 
     $second_item = $items->eq(1);
     $this->assertEquals('that red fruit', $second_item->filterXpath('//title')->text());
+    $this->assertEquals('&lt;p&gt;this is a cherry&lt;/p&gt; ', $second_item->filterXpath('//description')->html());
     $this->assertEquals('http://web:8080/build/node/3', $second_item->filterXpath('//link')->text());
     $this->assertEquals('http://web:8080/build/node/3', $second_item->filterXpath('//guid')->text());
     $this->assertEquals('Tue, 20 Oct 20 00:00:00 +1100', $second_item->filterXpath('//pubDate')->text());
+    // Assert modules subscribing to the ListPageRssItemAlterEvent can
+    // alter the item build.
+    $this->assertEquals('20/10/2020', $second_item->filterXpath('//creationDate')->text());
 
     // Change the node title and assert the response has changed.
     $node->set('title', 'List page test updated');

--- a/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
+++ b/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
@@ -99,6 +99,7 @@ class ListPageRssControllerTest extends WebDriverTestBase {
     $this->assertEquals(2, $items->count());
     $first_item = $items->eq(0);
     $this->assertEquals('that yellow fruit', $first_item->filterXpath('//title')->text());
+    $this->assertEquals('&lt;p&gt;this is a banana&lt;/p&gt; ', $first_item->filterXpath('//description')->html());
     $this->assertEquals('http://web:8080/build/node/2', $first_item->filterXpath('//link')->text());
     $this->assertEquals('http://web:8080/build/node/2', $first_item->filterXpath('//guid')->text());
     $this->assertEquals('Tue, 20 Oct 20 00:00:00 +1100', $first_item->filterXpath('//pubDate')->text());

--- a/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
+++ b/tests/src/FunctionalJavascript/ListPageRssControllerTest.php
@@ -100,6 +100,7 @@ class ListPageRssControllerTest extends WebDriverTestBase {
     $first_item = $items->eq(0);
     $this->assertEquals('that yellow fruit', $first_item->filterXpath('//title')->text());
     $this->assertEquals('http://web:8080/build/node/2', $first_item->filterXpath('//link')->text());
+    $this->assertEquals('http://web:8080/build/node/2', $first_item->filterXpath('//guid')->text());
     $this->assertEquals('Tue, 20 Oct 20 00:00:00 +1100', $first_item->filterXpath('//pubDate')->text());
     // Assert modules subscribing to the ListPageRssItemAlterEvent can
     // alter the item build.
@@ -108,6 +109,7 @@ class ListPageRssControllerTest extends WebDriverTestBase {
     $second_item = $items->eq(1);
     $this->assertEquals('that red fruit', $second_item->filterXpath('//title')->text());
     $this->assertEquals('http://web:8080/build/node/3', $second_item->filterXpath('//link')->text());
+    $this->assertEquals('http://web:8080/build/node/3', $second_item->filterXpath('//guid')->text());
     $this->assertEquals('Tue, 20 Oct 20 00:00:00 +1100', $second_item->filterXpath('//pubDate')->text());
 
     // Change the node title and assert the response has changed.


### PR DESCRIPTION
## EWPP-453
### Description

Execute and render the RSS list for list pages.

### Change log

- Added:
- Changed: Execute and render the RSS list
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

