### PR TITLE
Support entity types w/o bundles, such as 'user'

### DIFF
--- a/src/Form/ListPageConfigurationSubForm.php
+++ b/src/Form/ListPageConfigurationSubForm.php
@@ -497,7 +497,9 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
    *   The exposed filters.
    */
   protected function getBundleDefaultExposedFilters(ListSourceInterface $list_source): array {
-    $bundle_entity_type = $this->entityTypeManager->getDefinition($list_source->getEntityType())->getBundleEntityType();
+    if (!$bundle_entity_type = $this->entityTypeManager->getDefinition($list_source->getEntityType())->getBundleEntityType()) {
+      return [];
+    }
     $storage = $this->entityTypeManager->getStorage($bundle_entity_type);
     $bundle = $storage->load($list_source->getBundle());
     return $bundle->getThirdPartySetting('oe_list_pages', 'default_exposed_filters', []);

--- a/src/ListSourceFactory.php
+++ b/src/ListSourceFactory.php
@@ -173,7 +173,7 @@ class ListSourceFactory implements ListSourceFactoryInterface {
     $configuration = $datasource->getConfiguration();
 
     if (!isset($configuration['bundles'])) {
-      // This an entity without a bundle, such as 'user'.
+      // This is an entity without a bundle, such as 'user'.
       return TRUE;
     }
 

--- a/src/ListSourceFactory.php
+++ b/src/ListSourceFactory.php
@@ -171,6 +171,12 @@ class ListSourceFactory implements ListSourceFactoryInterface {
    */
   protected function isBundleIndexed(DatasourceInterface $datasource, string $bundle): bool {
     $configuration = $datasource->getConfiguration();
+
+    if (!isset($configuration['bundles'])) {
+      // This an entity without a bundle, such as 'user'.
+      return TRUE;
+    }
+
     $selected = $configuration['bundles']['selected'];
     if ($configuration['bundles']['default'] === TRUE && empty($selected)) {
       // All bundles are indexed.


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

