### PR TITLE
Error in not loaded entities.

### DIFF
--- a/src/Plugin/MultiselectFilterField/EntityReferenceField.php
+++ b/src/Plugin/MultiselectFilterField/EntityReferenceField.php
@@ -121,10 +121,10 @@ class EntityReferenceField extends MultiSelectFilterFieldPluginBase {
     $values = [];
     foreach ($filter_values as $filter_value) {
       $entity = $entity_storage->load($filter_value);
-      $entity = $this->entityRepository->getTranslationFromContext($entity);
       if (!$entity) {
         continue;
       }
+      $entity = $this->entityRepository->getTranslationFromContext($entity);
 
       $values[] = $entity->label();
     }


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

When a multi-select entity reference field doesn't find the entity it tries to get the translation no a null variable and crashes the site.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed: Moved the getTranslationFromContextfunctionality after the existing null check.
- Security:

### Commands

```sh

```

