### PR TITLE
EWPP-1580: Restore dependency that was mistakenly deleted.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "drupal/emr": "^1.0-beta11",
         "drupal/facets": "^1.6",
         "drupal/multivalue_form_element": "^1.0@beta",
-        "drupal/search_api": "~1.17"
+        "drupal/search_api": "~1.17",
+        "symfony/options-resolver": "^4"
     },
     "require-dev": {
         "composer/installers": "^1.11",


### PR DESCRIPTION
The tests cannot catch this as they install all dependencies, including dev ones,
which include the options-resolver.