### PR TITLE
EWPP-1644: Open vocabulary association facet translations.

### DIFF
--- a/modules/oe_list_pages_open_vocabularies/oe_list_pages_open_vocabularies.post_update.php
+++ b/modules/oe_list_pages_open_vocabularies/oe_list_pages_open_vocabularies.post_update.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for OE list page open vocabularies.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\open_vocabularies\Entity\OpenVocabularyAssociation;
+
+/**
+ * Updates all the open vocabularies facets with translations.
+ *
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ */
+function oe_list_pages_open_vocabularies_post_update_0001(&$sandbox) {
+  // Facets may have been created based on vocabulary associations that are
+  // translated. This update goes through all the facets created as such
+  // and adds translations as needed.
+  if (!isset($sandbox['total'])) {
+    // Get all the association entities.
+    $ids = \Drupal::entityTypeManager()->getStorage('open_vocabulary_association')
+      ->getQuery()
+      ->execute();
+
+    if (!$ids) {
+      return t('No open vocabulary association facets had to be updated.');
+    }
+
+    $sandbox['ids'] = array_unique($ids);
+    $sandbox['total'] = count($sandbox['ids']);
+    $sandbox['current'] = 0;
+    $sandbox['updated'] = 0;
+    $default_language = \Drupal::languageManager()->getDefaultLanguage()->getId();
+    $languages = \Drupal::languageManager()->getLanguages();
+    $sandbox['languages'] = [];
+    foreach ($languages as $language) {
+      if ($language->getId() !== $default_language) {
+        $sandbox['languages'][] = $language->getId();
+      }
+    }
+  }
+
+  // We process one association at the time.
+  $id = array_pop($sandbox['ids']);
+  $association = OpenVocabularyAssociation::load($id);
+  $updated = FALSE;
+  foreach ($sandbox['languages'] as $language) {
+    /** @var \Drupal\language\Config\LanguageConfigOverride $config_translation */
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride($language, 'open_vocabularies.open_vocabulary_association.' . $association->id());
+    if ($config_translation->isNew()) {
+      // If it's new, it means there is no translation of this association in
+      // this language.
+      continue;
+    }
+
+    // If we have a translation, it means we need to simply resave it to trigger
+    // the update.
+    $config_translation->save();
+    $updated = TRUE;
+  }
+
+  $sandbox['current']++;
+  if ($updated) {
+    $sandbox['updated']++;
+  }
+
+  $sandbox['#finished'] = empty($sandbox['total']) ? 1 : ($sandbox['current'] / $sandbox['total']);
+
+  if ($sandbox['#finished'] === 1) {
+    return t('A total of @updated association facets have been updated with translations.', ['@updated' => $sandbox['updated']]);
+  }
+}

--- a/modules/oe_list_pages_open_vocabularies/oe_list_pages_open_vocabularies.services.yml
+++ b/modules/oe_list_pages_open_vocabularies/oe_list_pages_open_vocabularies.services.yml
@@ -1,4 +1,9 @@
 services:
   oe_list_pages_open_vocabularies.configurator:
     class: \Drupal\oe_list_pages_open_vocabularies\SearchApiConfigurator
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@oe_list_pages.list_source.factory']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@oe_list_pages.list_source.factory', '@language_manager']
+  oe_list_pages_open_vocabularies.config_subscriber:
+    class: Drupal\oe_list_pages_open_vocabularies\EventSubscriber\AssociationTranslationSubscriber
+    arguments: ['@oe_list_pages_open_vocabularies.configurator', '@entity_type.manager']
+    tags:
+      - { name: event_subscriber }

--- a/modules/oe_list_pages_open_vocabularies/src/EventSubscriber/AssociationTranslationSubscriber.php
+++ b/modules/oe_list_pages_open_vocabularies/src/EventSubscriber/AssociationTranslationSubscriber.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_list_pages_open_vocabularies\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Installer\InstallerKernel;
+use Drupal\language\Config\LanguageConfigOverrideCrudEvent;
+use Drupal\language\Config\LanguageConfigOverrideEvents;
+use Drupal\oe_list_pages_open_vocabularies\SearchApiConfigurator;
+use Drupal\open_vocabularies\OpenVocabularyAssociationInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Responds to changes to configuration translations.
+ */
+class AssociationTranslationSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The search API configurator.
+   *
+   * @var \Drupal\oe_list_pages_open_vocabularies\SearchApiConfigurator
+   */
+  protected $searchApiConfigurator;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a AssociationTranslationSubscriber.
+   *
+   * @param \Drupal\oe_list_pages_open_vocabularies\SearchApiConfigurator $searchApiConfigurator
+   *   The search API configurator.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(SearchApiConfigurator $searchApiConfigurator, EntityTypeManagerInterface $entityTypeManager) {
+    $this->searchApiConfigurator = $searchApiConfigurator;
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[LanguageConfigOverrideEvents::SAVE_OVERRIDE] = 'onOverrideChange';
+    $events[LanguageConfigOverrideEvents::DELETE_OVERRIDE] = 'onOverrideDelete';
+    return $events;
+  }
+
+  /**
+   * Updates the open vocabulary association facets with translations.
+   *
+   * @param \Drupal\language\Config\LanguageConfigOverrideCrudEvent $event
+   *   The language configuration event.
+   */
+  public function onOverrideChange(LanguageConfigOverrideCrudEvent $event) {
+    // We don't do anything if we are part of an install.
+    if (InstallerKernel::installationAttempted()) {
+      return;
+    }
+
+    $override = $event->getLanguageConfigOverride();
+    $config_id = $override->getName();
+    if (!$this->isAssociationTranslation($config_id)) {
+      return;
+    }
+
+    $association = $this->getAssociationFromConfigId($config_id);
+    if (!$association) {
+      return;
+    }
+
+    foreach ($association->getFields() as $field) {
+      $this->searchApiConfigurator->updateConfigTranslation($association, $field, $override);
+    }
+  }
+
+  /**
+   * Deletes the open vocabulary association facets translation.
+   *
+   * @param \Drupal\language\Config\LanguageConfigOverrideCrudEvent $event
+   *   The language configuration event.
+   */
+  public function onOverrideDelete(LanguageConfigOverrideCrudEvent $event) {
+    if (InstallerKernel::installationAttempted()) {
+      return;
+    }
+
+    $override = $event->getLanguageConfigOverride();
+    $config_id = $override->getName();
+    if (!$this->isAssociationTranslation($config_id)) {
+      return;
+    }
+
+    $association = $this->getAssociationFromConfigId($config_id);
+    if (!$association) {
+      return;
+    }
+
+    foreach ($association->getFields() as $field) {
+      $this->searchApiConfigurator->deleteConfigTranslation($association, $field, $override->getLangcode());
+    }
+  }
+
+  /**
+   * Checks if a config ID belongs to an association entity.
+   *
+   * @param string $config_id
+   *   The config ID.
+   *
+   * @return bool
+   *   Whether it belongs to an association.
+   */
+  protected function isAssociationTranslation(string $config_id): bool {
+    $entity_type_info = $this->entityTypeManager->getDefinition('open_vocabulary_association');
+    return strpos($config_id, $entity_type_info->getConfigPrefix()) !== FALSE;
+  }
+
+  /**
+   * Loads the association from its config ID.
+   *
+   * @param string $config_id
+   *   The config ID.
+   *
+   * @return \Drupal\open_vocabularies\OpenVocabularyAssociationInterface|null
+   *   The open vocabulary association.
+   */
+  protected function getAssociationFromConfigId(string $config_id): ?OpenVocabularyAssociationInterface {
+    $entity_type_info = $this->entityTypeManager->getDefinition('open_vocabulary_association');
+    $association_id = str_replace($entity_type_info->getConfigPrefix() . '.', '', $config_id);
+    return $this->entityTypeManager->getStorage('open_vocabulary_association')->load($association_id);
+  }
+
+}

--- a/modules/oe_list_pages_open_vocabularies/tests/src/Kernel/ListPagesSearchApiConfiguratorTest.php
+++ b/modules/oe_list_pages_open_vocabularies/tests/src/Kernel/ListPagesSearchApiConfiguratorTest.php
@@ -5,88 +5,14 @@ declare(strict_types = 1);
 namespace Drupal\Tests\oe_list_pages_open_vocabularies\Kernel;
 
 use Drupal\facets\Entity\Facet;
-use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\oe_list_pages_open_vocabularies\SearchApiConfigurator;
-use Drupal\open_vocabularies\Entity\OpenVocabulary;
 use Drupal\open_vocabularies\Entity\OpenVocabularyAssociation;
 use Drupal\search_api\Entity\Index;
 
 /**
  * Tests the list page open vocabularies configurator.
  */
-class ListPagesSearchApiConfiguratorTest extends EntityKernelTestBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public static $modules = [
-    'system',
-    'field',
-    'user',
-    'datetime',
-    'datetime_range',
-    'emr',
-    'entity_reference_revisions',
-    'emr_node',
-    'link',
-    'node',
-    'oe_list_pages',
-    'oe_list_pages_filters_test',
-    'oe_list_page_content_type',
-    'oe_list_pages_open_vocabularies',
-    'oe_list_pages_open_vocabularies_test',
-    'open_vocabularies',
-    'options',
-    'search_api',
-    'search_api_db',
-    'search_api_test_db',
-    'taxonomy',
-    'text',
-    'facets',
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-    $this->installEntitySchema('search_api_task');
-    $this->installSchema('search_api', ['search_api_item']);
-    $this->installEntitySchema('facets_facet');
-    $this->installEntitySchema('node');
-    $this->installEntitySchema('open_vocabulary');
-    $this->installEntitySchema('open_vocabulary_association');
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('taxonomy_term');
-    $this->installEntitySchema('entity_meta');
-    $this->installEntitySchema('entity_meta_relation');
-    $this->installConfig(['node',
-      'open_vocabularies',
-      'oe_list_pages',
-      'oe_list_page_content_type',
-      'oe_list_pages_filters_test',
-      'oe_list_pages_open_vocabularies_test',
-      'emr',
-      'emr_node',
-    ]);
-
-    // Create OpenVocabularies vocabularies.
-    $values = [
-      'id' => 'custom_vocabulary',
-      'label' => $this->randomString(),
-      'description' => $this->randomString(128),
-      'handler' => 'taxonomy',
-      'handler_settings' => [
-        'target_bundles' => [
-          'entity_test' => 'vocabulary_one',
-        ],
-      ],
-    ];
-
-    /** @var \Drupal\open_vocabularies\OpenVocabularyInterface $vocabulary */
-    $vocabulary = OpenVocabulary::create($values);
-    $vocabulary->save();
-  }
+class ListPagesSearchApiConfiguratorTest extends ListPagesSearchApiConfiguratorTestBase {
 
   /**
    * Tests SearchApiConfigurator reaction to vocabulary associations changes.
@@ -97,7 +23,7 @@ class ListPagesSearchApiConfiguratorTest extends EntityKernelTestBase {
     $field_id = 'open_vocabulary_bf49aa6d04';
     /** @var \Drupal\search_api\Entity\Index $node_index */
     $node_index = Index::load('node');
-    // Check facet do not exist.
+    // Check facet does not exist.
     $facet_1 = Facet::load($id_1);
     $this->assertNull($facet_1);
     $facet_2 = Facet::load($id_2);

--- a/modules/oe_list_pages_open_vocabularies/tests/src/Kernel/ListPagesSearchApiConfiguratorTestBase.php
+++ b/modules/oe_list_pages_open_vocabularies/tests/src/Kernel/ListPagesSearchApiConfiguratorTestBase.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_list_pages_open_vocabularies\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\open_vocabularies\Entity\OpenVocabulary;
+
+/**
+ * Base class for open vocabularies configurator.
+ */
+abstract class ListPagesSearchApiConfiguratorTestBase extends EntityKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'field',
+    'user',
+    'datetime',
+    'datetime_range',
+    'emr',
+    'entity_reference_revisions',
+    'emr_node',
+    'link',
+    'node',
+    'oe_list_pages',
+    'oe_list_pages_filters_test',
+    'oe_list_page_content_type',
+    'oe_list_pages_open_vocabularies',
+    'oe_list_pages_open_vocabularies_test',
+    'open_vocabularies',
+    'options',
+    'search_api',
+    'search_api_db',
+    'search_api_test_db',
+    'taxonomy',
+    'text',
+    'facets',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('search_api_task');
+    $this->installSchema('search_api', ['search_api_item']);
+    $this->installEntitySchema('facets_facet');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('open_vocabulary');
+    $this->installEntitySchema('open_vocabulary_association');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('entity_meta');
+    $this->installEntitySchema('entity_meta_relation');
+    $this->installConfig(['node',
+      'open_vocabularies',
+      'oe_list_pages',
+      'oe_list_page_content_type',
+      'oe_list_pages_filters_test',
+      'oe_list_pages_open_vocabularies_test',
+      'emr',
+      'emr_node',
+    ]);
+
+    // Create OpenVocabularies vocabularies.
+    $values = [
+      'id' => 'custom_vocabulary',
+      'label' => $this->randomString(),
+      'description' => $this->randomString(128),
+      'handler' => 'taxonomy',
+      'handler_settings' => [
+        'target_bundles' => [
+          'entity_test' => 'vocabulary_one',
+        ],
+      ],
+    ];
+
+    /** @var \Drupal\open_vocabularies\OpenVocabularyInterface $vocabulary */
+    $vocabulary = OpenVocabulary::create($values);
+    $vocabulary->save();
+  }
+
+}

--- a/modules/oe_list_pages_open_vocabularies/tests/src/Kernel/ListPagesSearchApiConfiguratorTranslationTest.php
+++ b/modules/oe_list_pages_open_vocabularies/tests/src/Kernel/ListPagesSearchApiConfiguratorTranslationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_list_pages_open_vocabularies\Kernel;
+
+use Drupal\facets\Entity\Facet;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\open_vocabularies\Entity\OpenVocabularyAssociation;
+
+/**
+ * Tests that the created facets are also translated after the associations.
+ */
+class ListPagesSearchApiConfiguratorTranslationTest extends ListPagesSearchApiConfiguratorTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'language',
+    'config_translation',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+  }
+
+  /**
+   * Tests that facets get translations.
+   *
+   * Whenever translations on the associations get created/updated/deleted,
+   * this needs to be reflected in the facet translation.
+   */
+  public function testVocabularyAssociationTranslationChanges(): void {
+    $facet_id_one = 'open_vocabularies_custom_vocabulary_open_vocabulary_node_content_type_one_field_open_vocabularies';
+    $facet_id_two = 'open_vocabularies_custom_vocabulary_open_vocabulary_node_content_type_two_field_open_vocabularies';
+
+    // Create an association with one field.
+    $fields = [
+      'node.content_type_one.field_open_vocabularies',
+    ];
+    $values = [
+      'label' => 'The association label',
+      'name' => 'open_vocabulary',
+      'widget_type' => 'options_select',
+      'required' => TRUE,
+      'help_text' => 'Some text',
+      'predicate' => 'http://example.com/#name',
+      'cardinality' => 5,
+      'vocabulary' => 'custom_vocabulary',
+      'fields' => $fields,
+    ];
+    $this->container->get('kernel')->rebuildContainer();
+    /** @var \Drupal\open_vocabularies\OpenVocabularyAssociationInterface $association */
+    $association = OpenVocabularyAssociation::create($values);
+    $association->save();
+
+    // Assert we have the facet.
+    /** @var \Drupal\facets\FacetInterface $facet */
+    $facet = Facet::load($facet_id_one);
+    $this->assertEquals('list_facet_source:node:content_type_one', $facet->getFacetSourceId());
+
+    // Check the translatable values were correctly saved.
+    $this->assertEquals('The association label', $facet->label());
+
+    // Alter the association, change label and add to a new field.
+    $association = OpenVocabularyAssociation::load($association->id());
+    $fields = [
+      'node.content_type_one.field_open_vocabularies',
+      'node.content_type_two.field_open_vocabularies',
+    ];
+    $association->set('fields', $fields);
+    $association->set('label', 'New association label');
+    $association->save();
+
+    // Check that the label was changed in the facet and a new facet got
+    // created.
+    $this->container->get('kernel')->rebuildContainer();
+    /** @var \Drupal\facets\FacetInterface $facet_one */
+    $facet = Facet::load($facet_id_one);
+    $this->assertEquals('New association label', $facet->label());
+    $facet_two = Facet::load($facet_id_two);
+    $this->assertEquals('New association label', $facet_two->label());
+
+    // Assert the facets don't have any translations yet.
+    /** @var \Drupal\language\Config\LanguageConfigOverride $config_translation */
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_one);
+    $this->assertTrue($config_translation->isNew());
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_two);
+    $this->assertTrue($config_translation->isNew());
+
+    // Create a translation of the association.
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'open_vocabularies.open_vocabulary_association.' . $association->id());
+    $config_translation->set('label', 'New association label in French');
+    $config_translation->save();
+
+    // Assert that the facets have also been translated.
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_one);
+    $this->assertFalse($config_translation->isNew());
+    $this->assertEquals('New association label in French', $config_translation->get('name'));
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_two);
+    $this->assertFalse($config_translation->isNew());
+    $this->assertEquals('New association label in French', $config_translation->get('name'));
+
+    // Update the translation and assert the changes are reflected.
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'open_vocabularies.open_vocabulary_association.' . $association->id());
+    $config_translation->set('label', 'New association label in French updated');
+    $config_translation->save();
+
+    /** @var \Drupal\language\Config\LanguageConfigOverride $config_translation */
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_one);
+    $this->assertFalse($config_translation->isNew());
+    $this->assertEquals('New association label in French updated', $config_translation->get('name'));
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_two);
+    $this->assertFalse($config_translation->isNew());
+    $this->assertEquals('New association label in French updated', $config_translation->get('name'));
+
+    // Delete the translation and assert the facet translation is also
+    // deleted.
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'open_vocabularies.open_vocabulary_association.' . $association->id());
+    $config_translation->delete();
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_one);
+    $this->assertTrue($config_translation->isNew());
+    $this->assertEmpty($config_translation->get());
+    $config_translation = \Drupal::languageManager()->getLanguageConfigOverride('fr', 'facets.facet.' . $facet_id_two);
+    $this->assertTrue($config_translation->isNew());
+    $this->assertEmpty($config_translation->get());
+  }
+
+}


### PR DESCRIPTION
This PR does 2 things:

* Ensures that when a list page facet is generated based on a vocabulary association, the facet also receives translations whenever the association is translated - translations are also kept in sync.
* Updates all existing faces that have been created based on associations with potential translations by resaving each vocabulary association translation override.