### PR TITLE
OEL-1677: Add support for Address fields.

### DIFF
--- a/modules/oe_list_pages_address/src/Plugin/facets/processor/FormatCountryCodeProcessor.php
+++ b/modules/oe_list_pages_address/src/Plugin/facets/processor/FormatCountryCodeProcessor.php
@@ -84,9 +84,10 @@ class FormatCountryCodeProcessor extends ProcessorPluginBase implements BuildPro
   public function supportsFacet(FacetInterface $facet) {
     $data_definition = $facet->getDataDefinition();
     if (in_array($data_definition->getDataType(), [
-      'string',
-      'field_item:string',
+      'field_item:address',
       'field_item:address_country',
+      'field_item:string',
+      'string',
     ])) {
       return TRUE;
     }


### PR DESCRIPTION
## OEL-1677

### Description

The FormatCountryCodeProcessor supports Text and Country fields, but the processor is capable of processing also Address fields.

### Change log

- Added: field_item:address to the supported list


