### PR TITLE
ERATRANS-442: Fixed issue that makes sort applied to be overwritten by default bundle sort.

### DIFF
--- a/src/ListExecutionManager.php
+++ b/src/ListExecutionManager.php
@@ -97,7 +97,7 @@ class ListExecutionManager implements ListExecutionManagerInterface {
     // If we have a specific sort, we use that first, followed by the default
     // bundle sort. Otherwise, just the bundle sort.
     $sort = $sort ? [$sort['name'] => $sort['direction']] : [];
-    if ($bundle_sort) {
+    if ($bundle_sort && empty($sort)) {
       $sort[$bundle_sort['name']] = $bundle_sort['direction'];
     }
 


### PR DESCRIPTION
## ERATRANS-442

### Description

Fixed issue that makes sort applied to be overwritten by default bundle sort.

### Change log
- Fixed: Issue that makes sort applied to be overwritten by default bundle sort.

