### PR TITLE
OE-List-pages-157: Add condition for matching sorts.

### DIFF
--- a/src/ListExecutionManager.php
+++ b/src/ListExecutionManager.php
@@ -97,7 +97,8 @@ class ListExecutionManager implements ListExecutionManagerInterface {
     // If we have a specific sort, we use that first, followed by the default
     // bundle sort. Otherwise, just the bundle sort.
     $sort = $sort ? [$sort['name'] => $sort['direction']] : [];
-    if ($bundle_sort) {
+    // We apply default sorting when is set or doesn't match with applied.
+    if (!empty($bundle_sort) && !isset($sort[$bundle_sort['name']])) {
       $sort[$bundle_sort['name']] = $bundle_sort['direction'];
     }
 


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

This is a PR to avoid the override of the matching sort when the default (bundle) and applied point to the same field.

For this case, the solution is to add a check to see if they are equal when checking if the default is set.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

