### PR TITLE
ELA-1049: fix php 8.2

### DIFF
--- a/src/FacetManipulationTrait.php
+++ b/src/FacetManipulationTrait.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\oe_list_pages;
 
+use Drupal\Core\Entity\EntityFieldManager;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\facets\FacetInterface;
@@ -12,6 +13,13 @@ use Drupal\facets\Result\ResultInterface;
  * Provides helper methods to manipulate facets and results.
  */
 trait FacetManipulationTrait {
+
+  /**
+   * The entity field manager
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManager
+   */
+  protected $entityFieldManager;
 
   /**
    * Processes and returns the results of a given facet.

--- a/src/MultiselectFilterFieldPluginManager.php
+++ b/src/MultiselectFilterFieldPluginManager.php
@@ -20,13 +20,6 @@ class MultiselectFilterFieldPluginManager extends DefaultPluginManager {
   use FacetManipulationTrait;
 
   /**
-   * The entity field manager.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected EntityFieldManagerInterface $entityFieldManager;
-
-  /**
    * Constructs a new multiselect filter field plugin manager.
    *
    * @param \Traversable $namespaces


### PR DESCRIPTION
**When using contextual filter in link list:**
Deprecated function: Creation of dynamic property Drupal\oe_list_pages_link_list_source\ContextualFilterValuesProcessor:: is deprecated in Drupal\oe_list_pages_link_list_source\ContextualFilterValuesProcessor->getFacetFieldDefinition() (line 99 of modules/contrib/oe_list_pages/src/FacetManipulationTrait.php)

## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

