### PR TITLE
OEL-3778: Pager more flexible as input[number].

### DIFF
--- a/src/Plugin/EntityMetaRelation/ListPage.php
+++ b/src/Plugin/EntityMetaRelation/ListPage.php
@@ -124,12 +124,9 @@ class ListPage extends EntityMetaRelationContentFormPluginBase {
     $form[$key] = $subform->buildForm($form[$key], $subform_state);
 
     $form[$key]['limit'] = [
-      '#type' => 'select',
+      '#type' => 'number',
+      '#min' => '0',
       '#title' => $this->t('The number of items to show per page'),
-      '#options' => [
-        10 => '10',
-        20 => '20',
-      ],
       '#default_value' => $entity_meta_wrapper->getConfiguration()['limit'] ?? 10,
     ];
 

--- a/tests/src/FunctionalJavascript/ListPagesFiltersTest.php
+++ b/tests/src/FunctionalJavascript/ListPagesFiltersTest.php
@@ -462,7 +462,7 @@ class ListPagesFiltersTest extends WebDriverTestBase {
     $node = $this->drupalGetNodeByTitle('List page for ct1');
     $this->drupalGet($node->toUrl('edit-form'));
     $this->clickLink('List Page');
-    $this->getSession()->getPage()->selectFieldOption('The number of items to show per page', '20');
+    $this->getSession()->getPage()->fillField('The number of items to show per page', '20');
     $page->pressButton('Save');
     $this->assertCount(20, $this->getSession()->getPage()->findAll('css', '.node--type-content-type-one'));
     $assert_session->pageTextContains('Showing results 1 to 20');


### PR DESCRIPTION
### Description
Updates the pager element to use a more flexible <input type="number"> instead of a restrictive <select> element with predefined options. This allows content editors to enter any number of items they wish to display per page, providing much more flexibility for list page configuration.

The functional test has been updated to correctly interact with the new number input field using fillField() method instead of selectFieldOption() which was designed for <select> elements.


### Change log
- Changed:
  - Updated the pager limit field from a select list to a number input field
  - Updated test method from selectFieldOption() to fillField() to properly interact with number input fields
- Added:
  - Added minimum value constraint (0) for the number field
