### PR TITLE
EPHEH-649: Add item promotion and multi-criteria sort functionality.

### DIFF
--- a/config/schema/oe_list_pages.schema.yml
+++ b/config/schema/oe_list_pages.schema.yml
@@ -32,16 +32,55 @@ oe_list_pages.bundle_third_party_settings:
     default_view_mode:
       type: string
       label: 'The view mode to use when rendering the item in a list'
-    default_sort:
+    promotion:
       type: mapping
-      label: 'Sorting criteria'
+      label: 'Promotion settings (items to show first)'
       mapping:
-        name:
-          type: string
-          label: 'The field to sort by'
-        direction:
-          type: string
-          label: 'The direction of the sorting'
+        enabled:
+          type: boolean
+          label: 'Enable promotion'
+        rules:
+          type: sequence
+          label: 'Promotion rules (each rule can have multiple conditions combined with AND)'
+          sequence:
+            type: mapping
+            label: 'Promotion rule'
+            mapping:
+              weight:
+                type: integer
+                label: 'Order weight for this rule'
+              conditions:
+                type: sequence
+                label: 'Conditions (all must match for the rule to apply)'
+                sequence:
+                  type: mapping
+                  label: 'Condition'
+                  mapping:
+                    field:
+                      type: string
+                      label: 'The field to check'
+                    operator:
+                      type: string
+                      label: 'The comparison operator (=, >, <, >=, <=, <>)'
+                    value:
+                      type: string
+                      label: 'The value to compare against'
+    default_sort:
+      type: sequence
+      label: 'Sorting criteria (for non-promoted items)'
+      sequence:
+        type: mapping
+        label: 'Sort criterion'
+        mapping:
+          name:
+            type: string
+            label: 'The field to sort by'
+          direction:
+            type: string
+            label: 'The direction of the sorting'
+          weight:
+            type: integer
+            label: 'Weight for sorting'
     default_exposed_filters:
       type: sequence
       label: 'Exposed filters'
@@ -51,6 +90,9 @@ oe_list_pages.bundle_third_party_settings:
     default_filter_values_allowed:
       type: boolean
       label: 'Allow this content type to define default values for its filters'
+    show_promotion_badge:
+      type: boolean
+      label: 'Show visual badge on promoted/highlighted items'
 
 search_api.index.*.third_party.oe_list_pages:
   type: mapping

--- a/css/oe-list-pages-promoted.css
+++ b/css/oe-list-pages-promoted.css
@@ -1,0 +1,56 @@
+/**
+ * @file
+ * Styles for promoted/highlighted items in list pages.
+ */
+
+/* Wrapper for list items */
+.oe-list-pages-item {
+  position: relative;
+}
+
+/* Promoted item styling */
+.oe-list-pages-item--promoted {
+  position: relative;
+}
+
+/* Promoted badge */
+.oe-list-pages-promoted-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  padding: 4px 8px;
+  background-color: #ffc107;
+  color: #212529;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 0 0 4px 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.oe-list-pages-promoted-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Alternative: Badge as inline element instead of absolute positioned */
+.oe-list-pages-item--promoted.oe-list-pages-item--inline-badge .oe-list-pages-promoted-badge {
+  position: static;
+  display: inline-flex;
+  margin-right: 8px;
+  border-radius: 4px;
+}
+
+/* Screen reader only text */
+.visually-hidden {
+  position: absolute !important;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  width: 1px;
+  height: 1px;
+  word-wrap: normal;
+}

--- a/oe_list_pages.libraries.yml
+++ b/oe_list_pages.libraries.yml
@@ -1,0 +1,5 @@
+promoted-items:
+  version: VERSION
+  css:
+    component:
+      css/oe-list-pages-promoted.css: {}

--- a/oe_list_pages.module
+++ b/oe_list_pages.module
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Template\Attribute;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\oe_list_pages\SkosConceptHierarchicalHandler;
 use Drupal\oe_list_pages\TaxonomyTermHierarchicalHandler;
@@ -32,6 +33,13 @@ function oe_list_pages_theme($existing, $type, $theme, $path) {
       'variables' => [
         'items' => [],
         'label' => NULL,
+      ],
+    ],
+    'oe_list_pages_result_item' => [
+      'variables' => [
+        'content' => NULL,
+        'is_promoted' => FALSE,
+        'attributes' => [],
       ],
     ],
     'oe_list_pages_rss' => [
@@ -123,5 +131,53 @@ function oe_list_pages_entity_type_build(array &$entity_types) {
   }
   if (isset($entity_types['skos_concept'])) {
     $entity_types['skos_concept']->setHandlerClass('oe_list_pages_hierarchy', SkosConceptHierarchicalHandler::class);
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for node_type_form.
+ */
+function oe_list_pages_form_node_type_form_alter(array &$form, FormStateInterface $form_state) {
+  /** @var \Drupal\node\NodeTypeInterface $node_type */
+  $node_type = $form_state->getFormObject()->getEntity();
+
+  // Only show the List Pages settings on content types that have the
+  // oe_list_page entity meta relation (i.e., List Page content types).
+  $emr_bundles = $node_type->getThirdPartySetting('emr', 'entity_meta_bundles', []);
+  if (!in_array('oe_list_page', $emr_bundles)) {
+    return;
+  }
+
+  $form['oe_list_pages'] = [
+    '#type' => 'details',
+    '#title' => t('List Pages settings'),
+    '#group' => 'additional_settings',
+    '#weight' => 35,
+  ];
+
+  $form['oe_list_pages']['show_promotion_badge'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show visual badge on highlighted items'),
+    '#description' => t('When enabled, items that are highlighted (promoted) in all list pages will display a visual indicator (star badge). When disabled, the promotion functionality still works but without visual indication.'),
+    '#default_value' => $node_type->getThirdPartySetting('oe_list_pages', 'show_promotion_badge', FALSE),
+  ];
+
+  $form['#entity_builders'][] = 'oe_list_pages_form_node_type_form_builder';
+}
+
+/**
+ * Entity builder for the node type form with third party options.
+ */
+function oe_list_pages_form_node_type_form_builder($entity_type, $type, &$form, FormStateInterface $form_state) {
+  $type->setThirdPartySetting('oe_list_pages', 'show_promotion_badge', (bool) $form_state->getValue('show_promotion_badge'));
+}
+
+/**
+ * Prepares variables for oe-list-pages-result-item templates.
+ */
+function template_preprocess_oe_list_pages_result_item(array &$variables) {
+  // Ensure attributes is an Attribute object.
+  if (!($variables['attributes'] instanceof Attribute)) {
+    $variables['attributes'] = new Attribute($variables['attributes'] ?? []);
   }
 }

--- a/oe_list_pages.services.yml
+++ b/oe_list_pages.services.yml
@@ -12,7 +12,7 @@ services:
       - { name: event_subscriber }
   oe_list_pages.execution_manager:
     class: Drupal\oe_list_pages\ListExecutionManager
-    arguments: ['@oe_list_pages.list_source.factory', '@entity_type.manager', '@request_stack', '@language_manager', '@oe_list_pages.sort_options_resolver']
+    arguments: ['@oe_list_pages.list_source.factory', '@entity_type.manager', '@request_stack', '@language_manager', '@oe_list_pages.sort_options_resolver', '@oe_list_pages.custom_sort_processor']
   oe_list_pages.builder:
     class: Drupal\oe_list_pages\ListBuilder
     arguments: ['@oe_list_pages.execution_manager', '@entity_type.manager', '@pager.manager', '@entity.repository', '@form_builder', '@facets.utility.url_generator', '@plugin.manager.facets.processor', '@request_stack', '@plugin.manager.facets.url_processor', '@plugin.manager.multiselect_filter_field', '@oe_list_pages.list_source.factory', '@oe_list_pages.sort_options_resolver']
@@ -21,10 +21,12 @@ services:
     arguments: ['@oe_list_pages.list_facet_manager_wrapper']
   oe_list_pages.list_page_configuration_subform_factory:
     class: Drupal\oe_list_pages\Form\ListPageConfigurationSubformFactory
-    arguments: ['@entity_type.manager', '@entity_type.bundle.info', '@event_dispatcher', '@oe_list_pages.list_source.factory', '@oe_list_pages.preset_filters_builder', '@oe_list_pages.sort_options_resolver']
+    arguments: ['@entity_type.manager', '@entity_type.bundle.info', '@event_dispatcher', '@oe_list_pages.list_source.factory', '@oe_list_pages.preset_filters_builder', '@oe_list_pages.sort_options_resolver', '@entity_field.manager']
   plugin.manager.multiselect_filter_field:
     class: Drupal\oe_list_pages\MultiselectFilterFieldPluginManager
     parent: default_plugin_manager
   oe_list_pages.sort_options_resolver:
     class: Drupal\oe_list_pages\ListPageSortOptionsResolver
     arguments: ['@entity_type.manager', '@event_dispatcher']
+  oe_list_pages.custom_sort_processor:
+    class: Drupal\oe_list_pages\CustomSortProcessor

--- a/src/CustomSortProcessor.php
+++ b/src/CustomSortProcessor.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\oe_list_pages;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Plugin\search_api\data_type\value\TextValueInterface;
+use Drupal\search_api\Query\ResultSetInterface;
+
+/**
+ * Processes Search API results to apply promotion (show specific items first).
+ *
+ * This processor re-orders search results based on "promotion" configuration.
+ * Items matching promoted values appear first in the specified order,
+ * followed by remaining items in their original sort order.
+ *
+ * Example: For a Category field with values [A, B, C, D] sorted ASC:
+ * - Without promotion: A, B, C, D
+ * - With promotion [C, A]: C, A, B, D (promoted first, then others)
+ */
+class CustomSortProcessor {
+
+  /**
+   * Processes results to apply promotion (show promoted items first).
+   *
+   * @param \Drupal\search_api\Query\ResultSetInterface $results
+   *   The Search API result set.
+   * @param array $promotion
+   *   Promotion settings with:
+   *   - enabled: bool
+   *   - values: array of {field, value, weight}.
+   *
+   * @return \Drupal\search_api\Query\ResultSetInterface
+   *   The result set with promoted items first.
+   */
+  public function processResults(ResultSetInterface $results, array $promotion): ResultSetInterface {
+    if (empty($promotion['enabled']) || empty($promotion['values'])) {
+      return $results;
+    }
+
+    $items = $results->getResultItems();
+
+    if (empty($items)) {
+      return $results;
+    }
+
+    // Filter out promotion values without field.
+    $valid_promotion_values = array_filter($promotion['values'], function ($pv) {
+      return !empty($pv['field']) && isset($pv['value']) && $pv['value'] !== '';
+    });
+
+    if (empty($valid_promotion_values)) {
+      return $results;
+    }
+
+    // Ensure fields are extracted from each item.
+    foreach ($items as $item) {
+      // Force field extraction by getting all fields.
+      $item->getFields(TRUE);
+    }
+
+    $items = $this->sortByPromotedValues($items, $valid_promotion_values);
+
+    // Update the result set with reordered items.
+    $results->setResultItems($items);
+
+    return $results;
+  }
+
+  /**
+   * Reorders items to show promoted values first, keeping others in order.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface[] $items
+   *   The search result items (already sorted by Search API).
+   * @param array $promoted_values
+   *   Array of promoted values with 'field', 'value', and 'weight' keys.
+   *
+   * @return \Drupal\search_api\Item\ItemInterface[]
+   *   Items ordered: promoted first (by weight), then others (original order).
+   */
+  protected function sortByPromotedValues(array $items, array $promoted_values): array {
+    // Build a map of field+value combinations to their weights.
+    // Lower weight = higher priority (appears first).
+    $promoted_map = [];
+    foreach ($promoted_values as $pv) {
+      $field = $pv['field'] ?? '';
+      $value = (string) ($pv['value'] ?? '');
+      if (!empty($field) && $value !== '') {
+        $key = $field . '::' . $value;
+        $promoted_map[$key] = $pv['weight'] ?? 0;
+      }
+    }
+
+    // Separate items into promoted and non-promoted, preserving order.
+    $promoted_items = [];
+    $other_items = [];
+
+    foreach ($items as $item_id => $item) {
+      $matched_weight = NULL;
+
+      // Check each promoted field+value combination.
+      foreach ($promoted_values as $pv) {
+        $field = $pv['field'] ?? '';
+        $expected_value = trim((string) ($pv['value'] ?? ''));
+        if (empty($field) || $expected_value === '') {
+          continue;
+        }
+
+        $field_value = $this->getFieldValue($item, $field);
+        $field_value_str = $field_value !== NULL ? trim((string) $field_value) : '';
+
+        if ($field_value_str === $expected_value) {
+          $key = $field . '::' . $expected_value;
+          $weight = $promoted_map[$key] ?? 0;
+          // Use the lowest weight if multiple promotions match.
+          if ($matched_weight === NULL || $weight < $matched_weight) {
+            $matched_weight = $weight;
+          }
+        }
+      }
+
+      if ($matched_weight !== NULL) {
+        $promoted_items[] = [
+          'item_id' => $item_id,
+          'item' => $item,
+          'weight' => $matched_weight,
+        ];
+      }
+      else {
+        $other_items[$item_id] = $item;
+      }
+    }
+
+    // Sort promoted items by their weight.
+    usort($promoted_items, fn($a, $b) => $a['weight'] <=> $b['weight']);
+
+    // Build final result: promoted items first, then others.
+    $sorted_items = [];
+    foreach ($promoted_items as $entry) {
+      $sorted_items[$entry['item_id']] = $entry['item'];
+    }
+    foreach ($other_items as $item_id => $item) {
+      $sorted_items[$item_id] = $item;
+    }
+
+    return $sorted_items;
+  }
+
+  /**
+   * Gets the field value from a Search API item.
+   *
+   * First tries to get the value from the Search API item's indexed fields.
+   * If not available, falls back to loading the original entity.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface $item
+   *   The search result item.
+   * @param string $field_name
+   *   The field name (Search API field identifier).
+   *
+   * @return mixed
+   *   The field value as a scalar, or NULL if not found.
+   */
+  protected function getFieldValue(ItemInterface $item, string $field_name) {
+    // Always load from the entity for reliability.
+    // Search API field extraction can be inconsistent across backends.
+    $value = $this->getFieldValueFromEntity($item, $field_name);
+    if ($value !== NULL) {
+      return $value;
+    }
+
+    // Fallback to Search API item's fields.
+    $field = $item->getField($field_name);
+    if ($field) {
+      $values = $field->getValues();
+      if (!empty($values)) {
+        $value = reset($values);
+
+        // Handle TextValue objects (used for fulltext fields like title).
+        if ($value instanceof TextValueInterface) {
+          return $value->getText();
+        }
+
+        // Handle other object types that might have a string representation.
+        if (is_object($value) && method_exists($value, '__toString')) {
+          return (string) $value;
+        }
+
+        return $value;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Gets a field value by loading the original entity.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface $item
+   *   The search result item.
+   * @param string $field_name
+   *   The Search API field identifier.
+   *
+   * @return mixed
+   *   The field value, or NULL if not found.
+   */
+  protected function getFieldValueFromEntity(ItemInterface $item, string $field_name) {
+    try {
+      $original_object = $item->getOriginalObject();
+      if (!$original_object) {
+        return NULL;
+      }
+
+      $entity = $original_object->getValue();
+      if (!$entity instanceof FieldableEntityInterface) {
+        return NULL;
+      }
+
+      // Get the property path from the index field to find the entity field.
+      $index = $item->getIndex();
+      $index_field = $index->getField($field_name);
+      if (!$index_field) {
+        return NULL;
+      }
+
+      $property_path = $index_field->getPropertyPath();
+      // Get the base field name (before any ':' for nested properties).
+      $entity_field_name = explode(':', $property_path)[0];
+
+      if (!$entity->hasField($entity_field_name)) {
+        return NULL;
+      }
+
+      $entity_field = $entity->get($entity_field_name);
+      if ($entity_field->isEmpty()) {
+        return NULL;
+      }
+
+      // For entity label (title), use the label() method directly.
+      if ($entity_field_name === 'title' && $entity instanceof EntityInterface) {
+        return $entity->label();
+      }
+
+      // Try to get the value - handle different field types.
+      $first_item = $entity_field->first();
+      if (!$first_item) {
+        return NULL;
+      }
+
+      // Get the main property name for this field type.
+      $main_property = $entity_field->getFieldDefinition()
+        ->getFieldStorageDefinition()
+        ->getMainPropertyName();
+
+      if ($main_property) {
+        try {
+          $property = $first_item->get($main_property);
+          if ($property) {
+            $value = $property->getValue();
+            // Handle cases where getValue returns an array.
+            if (is_array($value) && isset($value['value'])) {
+              return $value['value'];
+            }
+            return $value;
+          }
+        }
+        catch (\InvalidArgumentException $e) {
+          // Property doesn't exist, try common alternatives.
+        }
+      }
+
+      // Try common property names as fallback.
+      foreach (['value', 'target_id', 'uri'] as $property_name) {
+        try {
+          $property = $first_item->get($property_name);
+          if ($property) {
+            $value = $property->getValue();
+            if (is_array($value) && isset($value['value'])) {
+              return $value['value'];
+            }
+            return $value;
+          }
+        }
+        catch (\InvalidArgumentException $e) {
+          // Property doesn't exist, continue.
+        }
+      }
+    }
+    catch (\Exception $e) {
+      // Log the exception for debugging.
+      \Drupal::logger('oe_list_pages')->warning('Error getting field value for promotion: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+    }
+
+    return NULL;
+  }
+
+}

--- a/src/Form/ListPageConfigurationSubForm.php
+++ b/src/Form/ListPageConfigurationSubForm.php
@@ -8,6 +8,7 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -84,6 +85,13 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
   protected $sortOptionsResolver;
 
   /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
    * ListPageConfigurationSubformFactory constructor.
    *
    * @param \Drupal\oe_list_pages\ListPageConfiguration $configuration
@@ -100,8 +108,10 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
    *   The preset filters builder.
    * @param \Drupal\oe_list_pages\ListPageSortOptionsResolver $sortOptionsResolver
    *   The sort options resolver.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
+   *   The entity field manager.
    */
-  public function __construct(ListPageConfiguration $configuration, EntityTypeManagerInterface $entityTypeManager, EntityTypeBundleInfoInterface $entityTypeBundleInfo, EventDispatcherInterface $eventDispatcher, ListSourceFactoryInterface $listSourceFactory, DefaultFilterConfigurationBuilder $presetFiltersBuilder, ListPageSortOptionsResolver $sortOptionsResolver) {
+  public function __construct(ListPageConfiguration $configuration, EntityTypeManagerInterface $entityTypeManager, EntityTypeBundleInfoInterface $entityTypeBundleInfo, EventDispatcherInterface $eventDispatcher, ListSourceFactoryInterface $listSourceFactory, DefaultFilterConfigurationBuilder $presetFiltersBuilder, ListPageSortOptionsResolver $sortOptionsResolver, EntityFieldManagerInterface $entityFieldManager) {
     $this->entityTypeManager = $entityTypeManager;
     $this->entityTypeBundleInfo = $entityTypeBundleInfo;
     $this->eventDispatcher = $eventDispatcher;
@@ -109,6 +119,7 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
     $this->configuration = $configuration;
     $this->presetFiltersBuilder = $presetFiltersBuilder;
     $this->sortOptionsResolver = $sortOptionsResolver;
+    $this->entityFieldManager = $entityFieldManager;
   }
 
   /**
@@ -128,13 +139,18 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
     $entity_type_options = $this->getEntityTypeOptions();
     $entity_type_id = $this->configuration->getEntityType();
     $entity_type_bundle = $this->configuration->getBundle();
-    $configuration_sort = $this->configuration->getSort();
     $configuration_exposed_sort = $this->configuration->isExposedSort();
-    if ($configuration_sort) {
-      $configuration_sort = ListPageSortOptionsResolver::generateSortMachineName($configuration_sort);
-    }
-    else {
-      $configuration_sort = NULL;
+
+    // Initialize sort criteria if not set (backward compatibility).
+    $sort_criteria = $this->configuration->getDefaultSort();
+    if (empty($sort_criteria)) {
+      $this->configuration->setDefaultSort([
+        [
+          'name' => 'title',
+          'direction' => 'ASC',
+          'weight' => 0,
+        ],
+      ]);
     }
 
     $ajax_wrapper_id = 'list-page-configuration-' . ($form['#parents'] ? '-' . implode('-', $form['#parents']) : '');
@@ -148,19 +164,18 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
 
     $selected_entity_type = $form_state->has('entity_type') ? $form_state->get('entity_type') : $entity_type_id;
     $selected_bundle = $form_state->has('bundle') ? $form_state->get('bundle') : $entity_type_bundle;
-    $selected_sort = $form_state->has('sort') ? $form_state->get('sort') : $configuration_sort;
     $selected_exposed_sort = $form_state->has('exposed_sort') ? $form_state->get('exposed_sort') : $configuration_exposed_sort;
+
     if (!$form_state->has('entity_type')) {
       $form_state->set('entity_type', $selected_entity_type);
     }
 
+    // Entity type selection.
     $form['wrapper']['entity_type'] = [
       '#type' => 'select',
       '#title' => $this->t('Source entity type'),
       '#description' => $this->t('Select the entity type that will be used as the source for this list.'),
       '#options' => $entity_type_options,
-      // If there is no selection, the default entity type will be Node, due to
-      // self::fillDefaultEntityMetaValues().
       '#default_value' => $selected_entity_type,
       '#empty_value' => '',
       '#required' => TRUE,
@@ -172,16 +187,14 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
       '#executes_submit_callback' => TRUE,
       '#submit' => [[$this, 'entityTypeSelectSubmit']],
       '#limit_validation_errors' => [
-        array_merge($form['#parents'], [
-          'wrapper',
-          'entity_type',
-        ]),
+        array_merge($form['#parents'], ['wrapper', 'entity_type']),
       ],
     ];
 
     if (!empty($selected_entity_type)) {
       $bundle_options = $this->getBundleOptions($selected_entity_type);
 
+      // Bundle selection.
       $form['wrapper']['bundle'] = [
         '#type' => 'select',
         '#title' => $this->t('Source bundle'),
@@ -197,10 +210,7 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
         '#executes_submit_callback' => TRUE,
         '#submit' => [[$this, 'bundleSelectSubmit']],
         '#limit_validation_errors' => [
-          array_merge($form['#parents'], [
-            'wrapper',
-            'bundle',
-          ]),
+          array_merge($form['#parents'], ['wrapper', 'bundle']),
         ],
         '#process' => [
           [Select::class, 'processSelect'],
@@ -213,27 +223,19 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
         return $form;
       }
 
-      // Try to get the list source for the selected entity type and bundle.
+      // Get the list source for the selected entity type and bundle.
       $list_source = $this->listSourceFactory->get($selected_entity_type, $selected_bundle);
 
       if ($list_source) {
         $entity = $form_state->getFormObject()->getEntity() instanceof ContentEntityInterface ? $form_state->getFormObject()->getEntity() : NULL;
         $sort_options = $this->sortOptionsResolver->getSortOptions($list_source, context_entity: $entity);
-        $default_bundle_sort = $this->sortOptionsResolver->getBundleDefaultSort($list_source);
-        $form_state->set('default_bundle_sort', $default_bundle_sort);
-        if ($selected_sort && !isset($sort_options[$selected_sort])) {
-          // In case we no longer have the sort option, we should not show
-          // any default value.
-          $selected_sort = NULL;
-        }
-        $form['wrapper']['sort'] = [
-          '#type' => 'select',
-          '#options' => $sort_options,
-          '#title' => $this->t('Sort'),
-          '#default_value' => $selected_sort,
-          '#access' => count($sort_options) > 1,
-        ];
+        $form_state->set('default_bundle_sort', $this->sortOptionsResolver->getBundleDefaultSort($list_source));
 
+        // Sort criteria table with drag-and-drop support.
+        $form_parents = $form['#parents'] ?? [];
+        $this->buildSortCriteria($form['wrapper'], $form_state, $list_source, $form_parents);
+
+        // Expose sort checkbox (only if multiple sort criteria are allowed).
         $form['wrapper']['exposed_sort'] = [
           '#type' => 'checkbox',
           '#title' => $this->t('Expose sort'),
@@ -250,14 +252,13 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
         $exposed_filters = $this->getExposedFilters($list_source);
         $exposed_filters_overridden = $this->areExposedFiltersOverridden($list_source);
         $bundle_default_exposed_filters = $this->getBundleDefaultExposedFilters($list_source);
+
         if (!$exposed_filters_overridden && !$exposed_filters) {
-          // If the exposed filters are not overridden, the configuration should
-          // be empty so we want to default to the defaults set in the bundle
-          // third party setting.
+          // If exposed filters are not overridden, default to bundle settings.
           $exposed_filters = $bundle_default_exposed_filters;
         }
 
-        // Override checkbox.
+        // Override checkbox for exposed filters.
         $form['wrapper']['exposed_filters_override'] = [
           '#type' => 'checkbox',
           '#title' => $this->t('Override default exposed filters'),
@@ -271,6 +272,7 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
           'wrapper',
           'exposed_filters_override',
         ])) . ']';
+
         $form['wrapper']['exposed_filters'] = [
           '#type' => 'checkboxes',
           '#title' => $this->t('Exposed filters'),
@@ -286,15 +288,17 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
         if ($this->getConfiguration()->areDefaultFilterValuesAllowed()) {
           $parents = $form['#parents'] ?? [];
           $form['wrapper']['default_filter_values'] = [
-            '#parents' => array_merge($parents, [
-              'wrapper',
-              'default_filter_values',
-            ]),
+            '#parents' => array_merge($parents, ['wrapper', 'default_filter_values']),
             '#tree' => TRUE,
           ];
 
           $subform_state = SubformState::createForSubform($form['wrapper']['default_filter_values'], $form, $form_state);
-          $form['wrapper']['default_filter_values'] = $this->presetFiltersBuilder->buildDefaultFilters($form['wrapper']['default_filter_values'], $subform_state, $list_source, $this->getConfiguration());
+          $form['wrapper']['default_filter_values'] = $this->presetFiltersBuilder->buildDefaultFilters(
+            $form['wrapper']['default_filter_values'],
+            $subform_state,
+            $list_source,
+            $this->getConfiguration()
+          );
         }
       }
     }
@@ -335,6 +339,9 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
       $form_state->set($name, NULL);
     }
 
+    // Reset sort criteria when entity type changes (fields differ).
+    $form_state->set('sort_criteria', NULL);
+
     $form_state->setRebuild(TRUE);
   }
 
@@ -372,6 +379,9 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
     foreach ($remove as $name) {
       $form_state->set($name, NULL);
     }
+
+    // Reset sort criteria when bundle changes (fields may differ).
+    $form_state->set('sort_criteria', NULL);
 
     // When we change the bundle, we want to set the default exposed filter
     // values to the user input so that the checkboxes can be checked when the
@@ -415,41 +425,77 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
       'default_filter_values',
       'current_filters',
     ], []));
+
+    // Save entity type and bundle.
     $this->configuration->setEntityType($entity_type);
     $this->configuration->setBundle($entity_bundle);
     $this->configuration->setExposedFiltersOverridden($exposed_filters_overridden);
     $this->configuration->setDefaultFilterValues($default_filter_values);
+
     if (!$exposed_filters_overridden) {
       $exposed_filters = [];
     }
 
-    $sort = $form_state->getValue(['wrapper', 'sort']);
-    $default_bundle_sort = $form_state->get('default_bundle_sort');
-    if ($default_bundle_sort) {
-      // In case a bundle is not properly configured with a default sort, we
-      // need to check if the value is there before we generate a machine name.
-      $default_bundle_sort = ListPageSortOptionsResolver::generateSortMachineName($default_bundle_sort);
+    // Process promotion settings.
+    $promotion = $this->collectPromotionFromFormState($form_state);
+
+    // Filter out rules with no valid conditions.
+    if (!empty($promotion['rules'])) {
+      $promotion['rules'] = array_filter($promotion['rules'], function ($rule) {
+        if (empty($rule['conditions'])) {
+          return FALSE;
+        }
+        // Keep rules that have at least one complete condition.
+        foreach ($rule['conditions'] as $cond) {
+          if (!empty($cond['field']) && isset($cond['value']) && $cond['value'] !== '') {
+            return TRUE;
+          }
+        }
+        return FALSE;
+      });
+
+      // Filter out incomplete conditions within each rule.
+      foreach ($promotion['rules'] as &$rule) {
+        $rule['conditions'] = array_filter($rule['conditions'], function ($cond) {
+          return !empty($cond['field']) && isset($cond['value']) && $cond['value'] !== '';
+        });
+        $rule['conditions'] = array_values($rule['conditions']);
+      }
+
+      // Sort rules by weight.
+      uasort($promotion['rules'], fn($a, $b) => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+      $promotion['rules'] = array_values($promotion['rules']);
     }
 
-    if ($sort) {
-      [$name, $direction] = explode('__', $sort);
-      $this->configuration->setSort([
-        'name' => $name,
-        'direction' => strtoupper($direction),
-      ]);
+    // Enabled is determined by whether there are valid rules.
+    $promotion['enabled'] = !empty($promotion['rules']);
+
+    $this->configuration->setPromotion($promotion);
+
+    // Process sort criteria.
+    $raw_criteria = $this->collectSortCriteriaFromFormState($form_state);
+    $sort_criteria = [];
+    foreach ($raw_criteria as $criterion) {
+      if (!empty($criterion['name'])) {
+        $sort_criteria[] = [
+          'name' => $criterion['name'],
+          'direction' => $criterion['direction'] ?? 'ASC',
+          'weight' => $criterion['weight'] ?? 0,
+        ];
+      }
     }
 
-    if ($sort === $default_bundle_sort || $sort == "") {
-      // If the user configured the default bundle sort, we remove the value
-      // from the configuration in case later we change the defaults, we want
-      // the defaults to still take effect.
-      $this->configuration->setSort([]);
-    }
+    // Sort by weight before saving.
+    uasort($sort_criteria, fn($a, $b) => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+    $this->configuration->setDefaultSort(array_values($sort_criteria));
+
+    // Save exposed sort setting.
     $this->configuration->setExposedSort((bool) $form_state->getValue([
       'wrapper',
       'exposed_sort',
     ]));
 
+    // Save exposed filters.
     $this->configuration->setExposedFilters($exposed_filters);
   }
 
@@ -653,6 +699,804 @@ class ListPageConfigurationSubForm implements ListPageConfigurationSubformInterf
    */
   public static function generateSortMachineName(array $sort): string {
     return ListPageSortOptionsResolver::generateSortMachineName($sort);
+  }
+
+  /**
+   * Builds the promotion and sort criteria sections.
+   *
+   * Structure:
+   * 1. Sorting fieldset (wrapper)
+   *    1.1. Promotion section (optional) - items to show first
+   *    1.2. Sort criteria section - how to sort remaining items.
+   *
+   * @param array $form
+   *   The form array (the 'wrapper' container).
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param \Drupal\oe_list_pages\ListSourceInterface $list_source
+   *   The list source.
+   * @param array $form_parents
+   *   The parent form's #parents array for building #states selectors.
+   */
+  protected function buildSortCriteria(array &$form, FormStateInterface $form_state, ListSourceInterface $list_source, array $form_parents = []): void {
+    $wrapper_id = $this->getSortWrapperId();
+    $field_options = $this->getSortFieldOptions($list_source);
+
+    $form['sorting_container'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Default sorting'),
+      '#open' => TRUE,
+      '#tree' => TRUE,
+      '#attributes' => ['id' => $wrapper_id],
+    ];
+
+    // ==========================================
+    // SECTION 1: PROMOTION (items to show first)
+    // ==========================================
+    $this->buildPromotionSection($form['sorting_container'], $form_state, $field_options, $form_parents, $wrapper_id);
+
+    // ==========================================
+    // SECTION 2: SORT CRITERIA (for other items)
+    // ==========================================
+    $this->buildSortSection($form['sorting_container'], $form_state, $field_options, $wrapper_id);
+  }
+
+  /**
+   * Builds the promotion section of the form.
+   *
+   * @param array $form
+   *   The form array (the sorting_container).
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param array $field_options
+   *   Available field options.
+   * @param array $form_parents
+   *   The parent form's #parents array.
+   * @param string $wrapper_id
+   *   The AJAX wrapper ID.
+   */
+  protected function buildPromotionSection(array &$form, FormStateInterface $form_state, array $field_options, array $form_parents, string $wrapper_id): void {
+    $promotion = $this->getPromotionFromState($form_state);
+    $rules = $promotion['rules'] ?? [];
+
+    $form['promotion'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Promotion (highlight specific items first)'),
+      '#description' => $this->t('Items matching promotion rules will appear at the top of the list. Each rule can have multiple conditions (combined with AND).'),
+      '#open' => !empty($rules),
+      '#tree' => TRUE,
+    ];
+
+    $form['promotion']['rules'] = [
+      '#type' => 'table',
+      '#tree' => TRUE,
+      '#header' => [
+        '',
+        $this->t('Conditions'),
+        $this->t('Weight'),
+        $this->t('Operations'),
+      ],
+      '#empty' => $this->t('No promotion rules. Items will be displayed in default sort order.'),
+      '#tabledrag' => [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'promotion-rule-weight',
+        ],
+      ],
+    ];
+
+    // Sort rules by weight.
+    if (!empty($rules)) {
+      uasort($rules, fn($a, $b) => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+    }
+
+    $operator_options = $this->getOperatorOptions();
+
+    foreach ($rules as $rule_delta => $rule) {
+      $form['promotion']['rules'][$rule_delta] = [
+        '#attributes' => ['class' => ['draggable']],
+        'handle' => [
+          '#markup' => '',
+        ],
+        'conditions_wrapper' => $this->buildRuleConditions($rule, $rule_delta, $field_options, $operator_options, $wrapper_id),
+        'weight' => [
+          '#type' => 'weight',
+          '#title' => $this->t('Weight'),
+          '#title_display' => 'invisible',
+          '#default_value' => $rule['weight'] ?? $rule_delta,
+          '#attributes' => ['class' => ['promotion-rule-weight']],
+        ],
+        'operations' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Remove rule'),
+          '#name' => 'remove_rule_' . $rule_delta,
+          '#submit' => [[$this, 'removePromotionRule']],
+          '#ajax' => [
+            'callback' => [$this, 'updateSortCriteria'],
+            'wrapper' => $wrapper_id,
+          ],
+          '#limit_validation_errors' => [],
+        ],
+      ];
+    }
+
+    $form['promotion']['add_rule'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add promotion rule'),
+      '#name' => 'add_promotion_rule',
+      '#submit' => [[$this, 'addPromotionRule']],
+      '#ajax' => [
+        'callback' => [$this, 'updateSortCriteria'],
+        'wrapper' => $wrapper_id,
+      ],
+      '#limit_validation_errors' => [],
+    ];
+  }
+
+  /**
+   * Builds the conditions sub-form for a promotion rule.
+   *
+   * @param array $rule
+   *   The rule data.
+   * @param int $rule_delta
+   *   The rule index.
+   * @param array $field_options
+   *   Available field options.
+   * @param array $operator_options
+   *   Available operator options.
+   * @param string $wrapper_id
+   *   The AJAX wrapper ID.
+   *
+   * @return array
+   *   The conditions form element.
+   */
+  protected function buildRuleConditions(array $rule, int $rule_delta, array $field_options, array $operator_options, string $wrapper_id): array {
+    $element = [
+      '#type' => 'container',
+      '#tree' => TRUE,
+    ];
+
+    $conditions = $rule['conditions'] ?? [];
+    foreach ($conditions as $cond_delta => $condition) {
+      if ($cond_delta > 0) {
+        $element['and_' . $cond_delta] = [
+          '#markup' => '<div class="condition-and-separator"><strong>' . $this->t('AND') . '</strong></div>',
+        ];
+      }
+
+      $element[$cond_delta] = [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['condition-box'],
+          'style' => 'border: 1px solid #ccc; padding: 8px; margin-bottom: 5px; background: #f9f9f9;',
+        ],
+      ];
+
+      $element[$cond_delta]['field'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Field'),
+        '#options' => ['' => $this->t('- Select -')] + $field_options,
+        '#default_value' => $condition['field'] ?? '',
+      ];
+
+      $element[$cond_delta]['op_val'] = [
+        '#type' => 'container',
+        '#attributes' => [
+          'style' => 'display: flex; gap: 5px; align-items: flex-end;',
+        ],
+      ];
+
+      $element[$cond_delta]['op_val']['operator'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Op.'),
+        '#options' => $operator_options,
+        '#default_value' => $condition['operator'] ?? '=',
+      ];
+
+      $element[$cond_delta]['op_val']['value'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Value'),
+        '#default_value' => $condition['value'] ?? '',
+        '#size' => 12,
+        '#placeholder' => $this->t('"now" for date'),
+      ];
+
+      $element[$cond_delta]['op_val']['remove'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('×'),
+        '#name' => 'remove_condition_' . $rule_delta . '_' . $cond_delta,
+        '#submit' => [[$this, 'removePromotionCondition']],
+        '#ajax' => [
+          'callback' => [$this, 'updateSortCriteria'],
+          'wrapper' => $wrapper_id,
+        ],
+        '#limit_validation_errors' => [],
+        '#attributes' => [
+          'class' => ['button--small'],
+          'title' => $this->t('Remove'),
+          'style' => 'margin-bottom: 0;',
+        ],
+      ];
+    }
+
+    $element['add_condition'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('+ Condition'),
+      '#name' => 'add_condition_' . $rule_delta,
+      '#submit' => [[$this, 'addPromotionCondition']],
+      '#ajax' => [
+        'callback' => [$this, 'updateSortCriteria'],
+        'wrapper' => $wrapper_id,
+      ],
+      '#limit_validation_errors' => [],
+      '#attributes' => ['class' => ['button--small']],
+    ];
+
+    return $element;
+  }
+
+  /**
+   * Gets the available operator options for conditions.
+   *
+   * @return array
+   *   Array of operator labels keyed by operator.
+   */
+  protected function getOperatorOptions(): array {
+    return [
+      '=' => '=',
+      '<>' => '≠',
+      '>' => '>',
+      '>=' => '≥',
+      '<' => '<',
+      '<=' => '≤',
+    ];
+  }
+
+  /**
+   * Builds the sort criteria section of the form.
+   *
+   * @param array $form
+   *   The form array (the sorting_container).
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param array $field_options
+   *   Available field options.
+   * @param string $wrapper_id
+   *   The AJAX wrapper ID.
+   */
+  protected function buildSortSection(array &$form, FormStateInterface $form_state, array $field_options, string $wrapper_id): void {
+    $sort_criteria = $this->getSortCriteria($form_state);
+
+    $form['default_sort'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Sort criteria'),
+      '#description' => $this->t('Define how items are sorted. Promoted items (if any) will appear first, then remaining items will be sorted according to these criteria.'),
+      '#open' => TRUE,
+      '#tree' => TRUE,
+    ];
+
+    $form['default_sort']['criteria'] = [
+      '#type' => 'table',
+      '#tree' => TRUE,
+      '#header' => [
+        $this->t('Field'),
+        $this->t('Direction'),
+        ['data' => $this->t('Weight'), 'class' => ['element-hidden']],
+        $this->t('Operations'),
+      ],
+      '#empty' => $this->t('No sort criteria defined.'),
+      '#tabledrag' => [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'sort-criteria-weight',
+        ],
+      ],
+    ];
+
+    // Sort by weight.
+    uasort($sort_criteria, fn($a, $b) => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+
+    foreach ($sort_criteria as $delta => $criterion) {
+      $form['default_sort']['criteria'][$delta] = [
+        '#attributes' => ['class' => ['draggable']],
+        'name' => [
+          '#type' => 'select',
+          '#title' => $this->t('Field'),
+          '#title_display' => 'invisible',
+          '#options' => $field_options,
+          '#default_value' => $criterion['name'] ?? '',
+        ],
+        'direction' => [
+          '#type' => 'select',
+          '#title' => $this->t('Direction'),
+          '#title_display' => 'invisible',
+          '#options' => [
+            'ASC' => $this->t('Ascending'),
+            'DESC' => $this->t('Descending'),
+          ],
+          '#default_value' => $criterion['direction'] ?? 'ASC',
+        ],
+        'weight' => [
+          '#type' => 'weight',
+          '#title' => $this->t('Weight'),
+          '#title_display' => 'invisible',
+          '#default_value' => $criterion['weight'] ?? $delta,
+          '#attributes' => ['class' => ['sort-criteria-weight']],
+        ],
+        'operations' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Remove'),
+          '#name' => 'remove_sort_criterion_' . $delta,
+          '#submit' => [[$this, 'removeSortCriterion']],
+          '#ajax' => [
+            'callback' => [$this, 'updateSortCriteria'],
+            'wrapper' => $wrapper_id,
+          ],
+          '#limit_validation_errors' => [],
+        ],
+      ];
+    }
+
+    $form['default_sort']['add_criterion'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add sort criterion'),
+      '#submit' => [[$this, 'addSortCriterion']],
+      '#ajax' => [
+        'callback' => [$this, 'updateSortCriteria'],
+        'wrapper' => $wrapper_id,
+      ],
+      '#limit_validation_errors' => [],
+    ];
+  }
+
+  /**
+   * Gets the promotion settings from form state or configuration.
+   *
+   * Handles backward compatibility: converts old 'values' format to new 'rules'
+   * format.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The promotion settings.
+   */
+  protected function getPromotionFromState(FormStateInterface $form_state): array {
+    if ($form_state->has('promotion')) {
+      return $form_state->get('promotion');
+    }
+
+    $promotion = $this->configuration->getPromotion() ?: [];
+
+    // Backward compatibility: old 'values' format to new 'rules' format.
+    if (!empty($promotion['values']) && empty($promotion['rules'])) {
+      $promotion['rules'] = [];
+      foreach ($promotion['values'] as $pv) {
+        $promotion['rules'][] = [
+          'weight' => $pv['weight'] ?? 0,
+          'conditions' => [
+            [
+              'field' => $pv['field'] ?? '',
+              'operator' => '=',
+              'value' => $pv['value'] ?? '',
+            ],
+          ],
+        ];
+      }
+      unset($promotion['values']);
+    }
+
+    // Ensure 'enabled' is set based on rules presence.
+    $promotion['enabled'] = !empty($promotion['rules']);
+
+    return $promotion;
+  }
+
+  /**
+   * Builds a form element name from an array of parents.
+   *
+   * @param array $parents
+   *   The array of parent keys.
+   *
+   * @return string
+   *   The form element name (e.g., "parent[child][subchild]").
+   */
+  protected function buildFormElementName(array $parents): string {
+    $first = array_shift($parents);
+    if (empty($parents)) {
+      return $first;
+    }
+    return $first . '[' . implode('][', $parents) . ']';
+  }
+
+  /**
+   * Gets the current sort criteria from form state or configuration.
+   *
+   * After an add/remove AJAX round-trip the updated array is stored in
+   * form_state storage so that it survives the rebuild.  On initial load
+   * the saved configuration is used instead.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The sort criteria.
+   */
+  protected function getSortCriteria(FormStateInterface $form_state): array {
+    if ($form_state->has('sort_criteria')) {
+      return $form_state->get('sort_criteria');
+    }
+
+    return $this->configuration->getDefaultSort() ?: [];
+  }
+
+  /**
+   * Gets the AJAX wrapper ID for sort criteria.
+   *
+   * @return string
+   *   The wrapper ID.
+   */
+  protected function getSortWrapperId(): string {
+    return 'list-page-sort-criteria';
+  }
+
+  /**
+   * Form submission handler for adding a new sort criterion.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function addSortCriterion(array &$form, FormStateInterface $form_state): void {
+    $sort_criteria = $this->collectSortCriteriaFromFormState($form_state);
+    $this->collectPromotionFromFormState($form_state);
+
+    $sort_criteria[] = [
+      'name' => '',
+      'direction' => 'ASC',
+      'weight' => count($sort_criteria),
+    ];
+
+    $form_state->set('sort_criteria', $sort_criteria);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Form submission handler for removing a sort criterion.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function removeSortCriterion(array &$form, FormStateInterface $form_state): void {
+    $triggering_element = $form_state->getTriggeringElement();
+    $parents = $triggering_element['#array_parents'];
+    $criteria_index = array_search('criteria', $parents);
+    $delta = $parents[$criteria_index + 1];
+
+    $sort_criteria = $this->collectSortCriteriaFromFormState($form_state);
+    $this->collectPromotionFromFormState($form_state);
+    unset($sort_criteria[$delta]);
+
+    // Reindex and reassign sequential weights.
+    $sort_criteria = array_values($sort_criteria);
+    foreach ($sort_criteria as $i => &$criterion) {
+      $criterion['weight'] = $i;
+    }
+
+    $form_state->set('sort_criteria', $sort_criteria);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Form submission handler for adding a promotion rule.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function addPromotionRule(array &$form, FormStateInterface $form_state): void {
+    $promotion = $this->collectPromotionFromFormState($form_state);
+    $this->collectSortCriteriaFromFormState($form_state);
+
+    $promotion['rules'][] = [
+      'weight' => count($promotion['rules'] ?? []),
+      'conditions' => [
+        ['field' => '', 'operator' => '=', 'value' => ''],
+      ],
+    ];
+
+    $form_state->set('promotion', $promotion);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Form submission handler for removing a promotion rule.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function removePromotionRule(array &$form, FormStateInterface $form_state): void {
+    $triggering_element = $form_state->getTriggeringElement();
+    $button_name = $triggering_element['#name'];
+    preg_match('/remove_rule_(\d+)/', $button_name, $matches);
+    $rule_delta = (int) $matches[1];
+
+    $promotion = $this->collectPromotionFromFormState($form_state);
+    $this->collectSortCriteriaFromFormState($form_state);
+
+    if (isset($promotion['rules'][$rule_delta])) {
+      unset($promotion['rules'][$rule_delta]);
+      $promotion['rules'] = array_values($promotion['rules']);
+      foreach ($promotion['rules'] as $i => &$rule) {
+        $rule['weight'] = $i;
+      }
+    }
+
+    $form_state->set('promotion', $promotion);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Form submission handler for adding a condition to a rule.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function addPromotionCondition(array &$form, FormStateInterface $form_state): void {
+    $triggering_element = $form_state->getTriggeringElement();
+    $button_name = $triggering_element['#name'];
+    preg_match('/add_condition_(\d+)/', $button_name, $matches);
+    $rule_delta = (int) $matches[1];
+
+    $promotion = $this->collectPromotionFromFormState($form_state);
+    $this->collectSortCriteriaFromFormState($form_state);
+
+    if (isset($promotion['rules'][$rule_delta])) {
+      $promotion['rules'][$rule_delta]['conditions'][] = [
+        'field' => '',
+        'operator' => '=',
+        'value' => '',
+      ];
+    }
+
+    $form_state->set('promotion', $promotion);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Form submission handler for removing a condition from a rule.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function removePromotionCondition(array &$form, FormStateInterface $form_state): void {
+    $triggering_element = $form_state->getTriggeringElement();
+    $button_name = $triggering_element['#name'];
+    preg_match('/remove_condition_(\d+)_(\d+)/', $button_name, $matches);
+    $rule_delta = (int) $matches[1];
+    $cond_delta = (int) $matches[2];
+
+    $promotion = $this->collectPromotionFromFormState($form_state);
+    $this->collectSortCriteriaFromFormState($form_state);
+
+    if (isset($promotion['rules'][$rule_delta]['conditions'][$cond_delta])) {
+      unset($promotion['rules'][$rule_delta]['conditions'][$cond_delta]);
+      $promotion['rules'][$rule_delta]['conditions'] = array_values($promotion['rules'][$rule_delta]['conditions']);
+    }
+
+    $form_state->set('promotion', $promotion);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Collects sort criteria from form state.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The sort criteria array.
+   */
+  protected function collectSortCriteriaFromFormState(FormStateInterface $form_state): array {
+    $criteria_values = $form_state->getValue(['wrapper', 'sorting_container', 'default_sort', 'criteria'], []);
+    if (empty($criteria_values) || !is_array($criteria_values)) {
+      $sort_criteria = $this->configuration->getDefaultSort() ?: [];
+      $form_state->set('sort_criteria', $sort_criteria);
+      return $sort_criteria;
+    }
+
+    $sort_criteria = [];
+    foreach ($criteria_values as $delta => $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $sort_criteria[$delta] = [
+        'name' => $row['name'] ?? '',
+        'direction' => $row['direction'] ?? 'ASC',
+        'weight' => $row['weight'] ?? $delta,
+      ];
+    }
+
+    $form_state->set('sort_criteria', $sort_criteria);
+    return $sort_criteria;
+  }
+
+  /**
+   * Collects promotion settings from form state.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The promotion settings.
+   */
+  protected function collectPromotionFromFormState(FormStateInterface $form_state): array {
+    $promo_values = $form_state->getValue(['wrapper', 'sorting_container', 'promotion'], []);
+    if (empty($promo_values) || !is_array($promo_values)) {
+      $promotion = $this->configuration->getPromotion() ?: [];
+      $form_state->set('promotion', $promotion);
+      return $promotion;
+    }
+
+    $promotion = [
+      'enabled' => TRUE,
+      'rules' => [],
+    ];
+
+    $rules = $promo_values['rules'] ?? [];
+    if (is_array($rules)) {
+      foreach ($rules as $rule_delta => $rule) {
+        if (!is_array($rule)) {
+          continue;
+        }
+
+        $collected_rule = [
+          'weight' => $rule['weight'] ?? $rule_delta,
+          'conditions' => [],
+        ];
+
+        // Conditions are now in conditions_wrapper.
+        $conditions_wrapper = $rule['conditions_wrapper'] ?? [];
+        if (is_array($conditions_wrapper)) {
+          foreach ($conditions_wrapper as $cond_delta => $cond) {
+            // Skip non-numeric keys (like 'add_condition', 'and_X').
+            if (!is_numeric($cond_delta) || !is_array($cond)) {
+              continue;
+            }
+            // Operator and value are nested in 'op_val'.
+            $op_val = $cond['op_val'] ?? [];
+            $collected_rule['conditions'][] = [
+              'field' => $cond['field'] ?? '',
+              'operator' => $op_val['operator'] ?? '=',
+              'value' => $op_val['value'] ?? '',
+            ];
+          }
+        }
+
+        $promotion['rules'][$rule_delta] = $collected_rule;
+      }
+    }
+
+    // Promotion is enabled if there are rules.
+    $promotion['enabled'] = !empty($promotion['rules']);
+
+    $form_state->set('promotion', $promotion);
+    return $promotion;
+  }
+
+  /**
+   * Gets available sort field options for the select element.
+   *
+   * The fields come from TWO sources that are intersected:
+   *
+   * 1. Search API Index fields: Only fields that are indexed in Search API
+   *    can be used for sorting. These are configured in the Search API index
+   *    config (admin/config/search/search-api/index/[index_name]/fields).
+   *
+   * 2. Entity field definitions: We filter the index fields to only show
+   *    those that belong to the selected bundle. This is done by comparing
+   *    the index field's "property path" with the entity's field definitions.
+   *    - Base fields (title, created, changed, langcode, etc.) are available
+   *      for all bundles.
+   *    - Bundle-specific fields (field_*) are only shown for their bundle.
+   *
+   * The field's "property path" in Search API corresponds to the Drupal field
+   * name (e.g., "created", "field_publication_date"). For nested fields like
+   * entity references, the path may be "field_ref:entity:title".
+   *
+   * @param \Drupal\oe_list_pages\ListSourceInterface $list_source
+   *   The list source.
+   *
+   * @return array
+   *   Field options keyed by Search API field identifier.
+   */
+  protected function getSortFieldOptions(ListSourceInterface $list_source): array {
+    $field_options = [];
+    $index = $list_source->getIndex();
+    $entity_type = $list_source->getEntityType();
+    $bundle = $list_source->getBundle();
+
+    // Fields to exclude from sort options (not useful for sorting).
+    $excluded_fields = [
+      'status',
+      // The 'type' field is the bundle field - not useful for sorting within
+      // a single bundle context.
+      'type',
+      // Search API internal fields.
+      'search_api_datasource',
+      'search_api_language',
+    ];
+
+    // Get the field definitions for this bundle. This includes:
+    // - Base fields: title, created, changed, uid, langcode, etc.
+    // - Bundle-specific fields: field_* custom fields for this bundle.
+    $bundle_field_definitions = $this->entityFieldManager->getFieldDefinitions($entity_type, $bundle);
+    $bundle_field_names = array_keys($bundle_field_definitions);
+
+    foreach ($index->getFields() as $field_id => $field) {
+      // Skip excluded fields.
+      if (in_array($field_id, $excluded_fields)) {
+        continue;
+      }
+
+      // Get the property path to determine which entity field this index field
+      // corresponds to. The property path is the Drupal field name.
+      // For nested fields (e.g., "field_ref:entity:title"), we check the
+      // first part which is the main field on this entity.
+      $property_path = $field->getPropertyPath();
+      $field_name = explode(':', $property_path)[0];
+
+      // Only include fields that exist on the selected bundle.
+      // This filters out fields from other bundles in the same index.
+      if (in_array($field_name, $bundle_field_names)) {
+        $field_options[$field_id] = $field->getLabel();
+      }
+    }
+
+    // Sort alphabetically by label for better UX.
+    asort($field_options);
+
+    return $field_options;
+  }
+
+  /**
+   * AJAX callback to update the sort criteria table.
+   *
+   * Simply returns the rebuilt container element that carries the AJAX
+   * wrapper ID.  The form has already been rebuilt at this point because
+   * both add and remove callbacks call setRebuild().
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The updated sort criteria container.
+   */
+  public function updateSortCriteria(array &$form, FormStateInterface $form_state): array {
+    $triggering_element = $form_state->getTriggeringElement();
+    $parents = $triggering_element['#array_parents'];
+    // Find the sorting_container in the parents array.
+    $index = array_search('sorting_container', $parents);
+    if ($index === FALSE) {
+      // Fallback to default_sort for backward compatibility.
+      $index = array_search('default_sort', $parents);
+    }
+
+    return NestedArray::getValue($form, array_slice($parents, 0, $index + 1));
   }
 
 }

--- a/src/Form/ListPageConfigurationSubformFactory.php
+++ b/src/Form/ListPageConfigurationSubformFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\oe_list_pages\Form;
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\oe_list_pages\DefaultFilterConfigurationBuilder;
@@ -61,6 +62,13 @@ class ListPageConfigurationSubformFactory implements ListPageConfigurationFactor
   protected $sortOptionsResolver;
 
   /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
    * ListPageConfigurationSubformFactory constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -75,21 +83,24 @@ class ListPageConfigurationSubformFactory implements ListPageConfigurationFactor
    *   The preset list builder.
    * @param \Drupal\oe_list_pages\ListPageSortOptionsResolver $sortOptionsResolver
    *   The sort options resolver.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
+   *   The entity field manager.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, EntityTypeBundleInfoInterface $entityTypeBundleInfo, EventDispatcherInterface $eventDispatcher, ListSourceFactoryInterface $listSourceFactory, DefaultFilterConfigurationBuilder $presetFiltersBuilder, ListPageSortOptionsResolver $sortOptionsResolver) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, EntityTypeBundleInfoInterface $entityTypeBundleInfo, EventDispatcherInterface $eventDispatcher, ListSourceFactoryInterface $listSourceFactory, DefaultFilterConfigurationBuilder $presetFiltersBuilder, ListPageSortOptionsResolver $sortOptionsResolver, EntityFieldManagerInterface $entityFieldManager) {
     $this->entityTypeManager = $entityTypeManager;
     $this->entityTypeBundleInfo = $entityTypeBundleInfo;
     $this->eventDispatcher = $eventDispatcher;
     $this->listSourceFactory = $listSourceFactory;
     $this->presetFiltersBuilder = $presetFiltersBuilder;
     $this->sortOptionsResolver = $sortOptionsResolver;
+    $this->entityFieldManager = $entityFieldManager;
   }
 
   /**
    * {@inheritdoc}
    */
   public function getForm(ListPageConfiguration $configuration): ListPageConfigurationSubForm {
-    return new ListPageConfigurationSubForm($configuration, $this->entityTypeManager, $this->entityTypeBundleInfo, $this->eventDispatcher, $this->listSourceFactory, $this->presetFiltersBuilder, $this->sortOptionsResolver);
+    return new ListPageConfigurationSubForm($configuration, $this->entityTypeManager, $this->entityTypeBundleInfo, $this->eventDispatcher, $this->listSourceFactory, $this->presetFiltersBuilder, $this->sortOptionsResolver, $this->entityFieldManager);
   }
 
 }

--- a/src/ListBuilder.php
+++ b/src/ListBuilder.php
@@ -236,6 +236,17 @@ class ListBuilder implements ListBuilderInterface {
 
     $items = [];
 
+    // Get promoted entity IDs to mark them in the UI.
+    $promoted_entity_ids = $list_execution->getPromotedEntityIds();
+
+    // Check if the promotion badge display is enabled.
+    // This setting is on the List Page content type (e.g., oe_list_page),
+    // not on the source content type being listed.
+    $show_promotion_badge = $this->getShowPromotionBadgeSetting();
+
+    // Add cache tag for node type config changes.
+    $cache->addCacheTags(['config:node_type_list']);
+
     // Build the entities.
     $builder = $this->entityTypeManager->getViewBuilder($configuration->getEntityType());
     foreach ($result->getResultItems() as $item) {
@@ -248,13 +259,37 @@ class ListBuilder implements ListBuilderInterface {
 
       $cache->addCacheableDependency($entity);
       $entity = $this->entityRepository->getTranslationFromContext($entity);
-      $items[] = $builder->view($entity, $view_mode);
+
+      // Check if this item is promoted and if badge display is enabled.
+      $entity_key = $entity->getEntityTypeId() . ':' . $entity->id();
+      $is_promoted = $show_promotion_badge && in_array($entity_key, $promoted_entity_ids);
+
+      // Build the item with wrapper for promoted badge.
+      $item_build = $builder->view($entity, $view_mode);
+
+      if ($is_promoted) {
+        $items[] = [
+          '#theme' => 'oe_list_pages_result_item',
+          '#content' => $item_build,
+          '#is_promoted' => TRUE,
+          '#attributes' => ['class' => ['oe-list-pages-item', 'oe-list-pages-item--promoted']],
+        ];
+      }
+      else {
+        // When badge is disabled, render without the wrapper theme.
+        $items[] = $item_build;
+      }
     }
 
     $build['list'] = [
       '#theme' => 'item_list__oe_list_pages_results',
       '#items' => $items,
     ];
+
+    // Attach library for promoted items styling if badge display is enabled.
+    if ($show_promotion_badge && !empty($promoted_entity_ids)) {
+      $build['#attached']['library'][] = 'oe_list_pages/promoted-items';
+    }
 
     $cache->applyTo($build);
 
@@ -611,6 +646,48 @@ class ListBuilder implements ListBuilderInterface {
     }
 
     return $sort;
+  }
+
+  /**
+   * Gets the show_promotion_badge setting from List Page content types.
+   *
+   * This checks all node types that have the oe_list_page entity meta relation
+   * and returns TRUE if any of them has the setting enabled.
+   *
+   * @return bool
+   *   TRUE if the promotion badge should be shown.
+   */
+  protected function getShowPromotionBadgeSetting(): bool {
+    $show_badge = &drupal_static(__FUNCTION__);
+    if (isset($show_badge)) {
+      return $show_badge;
+    }
+
+    $show_badge = FALSE;
+
+    // Get all node types that have the oe_list_page entity meta relation.
+    try {
+      $node_type_storage = $this->entityTypeManager->getStorage('node_type');
+      $node_types = $node_type_storage->loadMultiple();
+
+      foreach ($node_types as $node_type) {
+        // Check if this node type has the EMR relation for list pages.
+        $emr_bundles = $node_type->getThirdPartySetting('emr', 'entity_meta_bundles', []);
+        if (in_array('oe_list_page', $emr_bundles)) {
+          // Check if the show_promotion_badge setting is enabled.
+          if ($node_type->getThirdPartySetting('oe_list_pages', 'show_promotion_badge', FALSE)) {
+            $show_badge = TRUE;
+            break;
+          }
+        }
+      }
+    }
+    catch (\Exception $e) {
+      // If something goes wrong, default to not showing the badge.
+      $show_badge = FALSE;
+    }
+
+    return $show_badge;
   }
 
 }

--- a/src/ListExecutionManager.php
+++ b/src/ListExecutionManager.php
@@ -202,14 +202,9 @@ class ListExecutionManager implements ListExecutionManagerInterface {
       );
       $result = $promotion_result['result'];
       $promoted_entity_ids = $promotion_result['promoted_entity_ids'];
-      $query = $list_source->getQuery([
-        'limit' => $limit,
-        'page' => $current_page,
-        'language' => $language,
-        'sort' => $sort,
-        'preset_filters' => $preset_filters,
-        'extra' => $configuration->getExtra(),
-      ]);
+      // Use the EXECUTED base query so cache tags accumulated during
+      // execution (facets, preset filters, etc.) are carried downstream.
+      $query = $promotion_result['query'];
     }
     else {
       $options = [
@@ -234,150 +229,56 @@ class ListExecutionManager implements ListExecutionManagerInterface {
   /**
    * Executes a list query with promotion support.
    *
-   * This method fetches promoted items first, then fills the remaining slots
-   * with regular items, ensuring no duplicates and correct pagination.
-   *
-   * @param \Drupal\oe_list_pages\ListSourceInterface $list_source
-   *   The list source.
-   * @param int $limit
-   *   The number of items per page.
-   * @param int $current_page
-   *   The current page number (0-indexed).
-   * @param string|array $language
-   *   The language(s) to filter by.
-   * @param array $sort
-   *   The sort configuration.
-   * @param array $preset_filters
-   *   The preset filters.
-   * @param array $extra
-   *   Extra configuration.
-   * @param array $promotion
-   *   The promotion settings.
+   * Promoted items (matching the promotion rules) are surfaced first in the
+   * virtual list; regular items (everything matching preset filters minus
+   * promoted) follow. The current page is then sliced out of that virtual
+   * list.
    *
    * @return array
    *   An array with keys:
    *   - 'result': The combined result set.
+   *   - 'query': The executed base query (carries cache tags).
    *   - 'promoted_entity_ids': Array of promoted entity IDs.
    */
   protected function executeListWithPromotion(ListSourceInterface $list_source, int $limit, int $current_page, $language, array $sort, array $preset_filters, array $extra, array $promotion): array {
+    // Step 1: Fetch every promoted item once.
+    //
+    // We need their total count to compute pagination offsets, and their IDs
+    // to exclude them from the regular query so an item never appears twice.
+    // Each rule can have multiple conditions combined with AND; items
+    // matching several rules are deduplicated by entity ID.
     $promoted_items = [];
     $promoted_entity_ids = [];
-
-    // Step 1: Always fetch ALL promoted items first (we need to know the count
-    // for pagination offset calculation, and their IDs to exclude them).
-    // Each rule can have multiple conditions (combined with AND).
-    $rules = $promotion['rules'] ?? [];
-
-    foreach ($rules as $rule) {
+    foreach ($promotion['rules'] ?? [] as $rule) {
       $conditions = $rule['conditions'] ?? [];
       if (empty($conditions)) {
         continue;
       }
-
-      // Create a query to find items matching this promotion rule.
-      // Fetch a reasonable maximum to get all promoted items.
-      $promo_query = $list_source->getQuery([
-        'limit' => 100,
-        'page' => 0,
-        'language' => $language,
-        'sort' => $sort,
-        'preset_filters' => $preset_filters,
-        'extra' => $extra,
-      ]);
-
-      // Add all conditions for this rule (AND logic).
-      foreach ($conditions as $condition) {
-        if (empty($condition['field'])) {
-          continue;
-        }
-
-        $field = $condition['field'];
-        $operator = $condition['operator'] ?? '=';
-        $value = $condition['value'] ?? '';
-
-        // Handle special value "now" for date comparisons.
-        if (strtolower($value) === 'now') {
-          $value = date('Y-m-d\TH:i:s');
-        }
-
-        // Map operators to Search API operators.
-        $promo_query->addCondition($field, $value, $operator);
-      }
-
-      $promo_result = $promo_query->execute();
-      $promo_items_found = $promo_result->getResultItems();
-
-      foreach ($promo_items_found as $item_id => $item) {
-        // Extract entity ID to avoid duplicates.
+      $rule_items = $this->fetchAllPromotedForRule(
+        $list_source, $language, $sort, $preset_filters, $extra, $conditions
+      );
+      foreach ($rule_items as $item_id => $item) {
+        // Dedupe by entity ID: an entity may match multiple rules but must
+        // appear only once in the promoted section.
         $entity_id = $this->extractEntityIdFromItem($item);
-        if ($entity_id && !in_array($entity_id, $promoted_entity_ids)) {
+        if ($entity_id && !in_array($entity_id, $promoted_entity_ids, TRUE)) {
           $promoted_items[$item_id] = $item;
           $promoted_entity_ids[] = $entity_id;
         }
       }
     }
-
     $total_promoted = count($promoted_items);
 
-    // Step 2: Calculate pagination.
-    // Promoted items come first, then regular items follow.
-    // We need to determine which items to show based on the virtual position.
+    // Step 2: Execute the base query.
     //
-    // Virtual list structure:
-    // [0 ... total_promoted-1] = promoted items
-    // [total_promoted ... total_items] = regular items
-    //
-    // For page N with limit L:
-    // - Start position: N * L
-    // - End position: (N + 1) * L - 1.
-    $page_start = $current_page * $limit;
-    $page_end = $page_start + $limit;
-
-    $final_items = [];
-
-    // Determine how many promoted items fall within this page's range.
-    if ($page_start < $total_promoted) {
-      // Some promoted items are on this page.
-      $promo_start = $page_start;
-      $promo_end = min($page_end, $total_promoted);
-      $promo_count = $promo_end - $promo_start;
-
-      // Get the slice of promoted items for this page.
-      $promoted_slice = array_slice($promoted_items, $promo_start, $promo_count, TRUE);
-      $final_items = $promoted_slice;
-    }
-
-    // Calculate how many regular items we need to fill the page.
-    $promoted_on_page = count($final_items);
-    $regular_needed = $limit - $promoted_on_page;
-
-    if ($regular_needed > 0) {
-      // Calculate offset for regular items.
-      // Regular items start after all promoted items in the virtual list.
-      // If we're on a page where promoted items end mid-page regular:
-      // offset = 0.
-      // If we're on a page without promoted items:
-      // offset = page_start - total_promoted.
-      $regular_offset = max(0, $page_start - $total_promoted);
-
-      // Fetch regular items excluding promoted ones.
-      $regular_items = $this->fetchRegularItemsExcludingPromoted(
-        $list_source,
-        $regular_needed,
-        $regular_offset,
-        $language,
-        $sort,
-        $preset_filters,
-        $extra,
-        $promoted_entity_ids
-      );
-
-      // Combine promoted + regular.
-      $final_items = $final_items + $regular_items;
-    }
-
-    // Create a result set with the final items.
-    // We need a base query to create a proper result set.
+    // It matches ALL items (promoted + regular) against preset filters,
+    // language and bundle. We use it for two things:
+    //  - its total result count, which drives the pager;
+    //  - its cache tags, accumulated during execute() by QuerySubscriber
+    //    (facets, preset filters, index) — this is why we keep the EXECUTED
+    //    query and return it to the caller, rather than re-creating a fresh
+    //    unexecuted one that would have no facet tags.
+    // Its item list is overwritten just below with our computed final set.
     $base_query = $list_source->getQuery([
       'limit' => $limit,
       'page' => $current_page,
@@ -387,46 +288,188 @@ class ListExecutionManager implements ListExecutionManagerInterface {
       'extra' => $extra,
     ]);
     $base_result = $base_query->execute();
+
+    // Step 3: Compute the page slice from a virtual list.
+    //
+    // Virtual list structure:
+    //   [0 ... total_promoted-1]        = promoted items in sort order
+    //   [total_promoted ... total-1]    = regular items in sort order
+    // For page N with limit L:
+    //   - Start position: N * L
+    //   - End position:   (N + 1) * L - 1
+    $page_start = $current_page * $limit;
+    $page_end = $page_start + $limit;
+
+    $final_items = [];
+
+    // How many promoted items fall within this page's range (possibly 0).
+    if ($page_start < $total_promoted) {
+      $promo_count = min($page_end, $total_promoted) - $page_start;
+      $final_items = array_slice($promoted_items, $page_start, $promo_count, TRUE);
+    }
+
+    // Step 4: Top up with regular items if the page is not full yet.
+    $regular_needed = $limit - count($final_items);
+    if ($regular_needed > 0) {
+      // Regular items start after promoted ones in the virtual list. When
+      // promoted items end mid-page the offset is 0 (no regular has been
+      // shown yet); otherwise it's the number of regulars already displayed
+      // on previous pages.
+      $regular_offset = max(0, $page_start - $total_promoted);
+      $final_items += $this->fetchRegularItemsExcludingPromoted(
+        $list_source,
+        $regular_needed,
+        $regular_offset,
+        $language,
+        $sort,
+        $preset_filters,
+        $extra,
+        array_keys($promoted_items)
+      );
+    }
+
+    // Swap the base query's items for our ordered promoted+regular set.
+    // The result's total count and cache tags stay intact.
     $base_result->setResultItems($final_items);
 
     return [
       'result' => $base_result,
+      'query' => $base_query,
       'promoted_entity_ids' => $promoted_entity_ids,
     ];
   }
 
   /**
+   * Fetches every item matching one promotion rule's conditions.
+   *
+   * Auto-paginates based on the result's reported total count so no item
+   * is silently dropped regardless of how many match the rule. This is a
+   * correctness requirement: the caller needs every promoted item ID to
+   * exclude them from the regular query; truncating would leak promoted
+   * items into the regular section and desynchronise pagination.
+   *
+   * The per-iteration batch size below is an internal optimisation — it
+   * controls queries-per-call vs. memory-per-response, not the feature's
+   * capacity. Larger = fewer Solr round-trips; smaller = smaller result
+   * objects in PHP memory. The feature works correctly for any batch
+   * size greater than zero.
+   */
+  protected function fetchAllPromotedForRule(ListSourceInterface $list_source, $language, array $sort, array $preset_filters, array $extra, array $conditions): array {
+    // Typical promotion rules match a handful of items, so a moderate
+    // batch fits the common case in a single round-trip while keeping
+    // per-response memory bounded on outlier deployments.
+    $batch_size = 100;
+    $items = [];
+    $page = 0;
+    $total = NULL;
+
+    do {
+      // Build a query matching this rule's conditions (AND logic) plus the
+      // base list constraints (preset filters, language, bundle, sort).
+      $query = $list_source->getQuery([
+        'limit' => $batch_size,
+        'page' => $page,
+        'language' => $language,
+        'sort' => $sort,
+        'preset_filters' => $preset_filters,
+        'extra' => $extra,
+      ]);
+      foreach ($conditions as $condition) {
+        if (empty($condition['field'])) {
+          continue;
+        }
+        $value = $condition['value'] ?? '';
+        // Special value "now" lets rules target e.g. "upcoming" items via
+        // a date comparison resolved at query time.
+        if (is_string($value) && strtolower($value) === 'now') {
+          $value = date('Y-m-d\TH:i:s');
+        }
+        $query->addCondition($condition['field'], $value, $condition['operator'] ?? '=');
+      }
+      $result = $query->execute();
+      $page_items = $result->getResultItems();
+      if (empty($page_items)) {
+        break;
+      }
+      $items += $page_items;
+      // Pick up the authoritative total on the first round-trip; it drives
+      // the loop termination without relying on a hard-coded cap.
+      if ($total === NULL) {
+        $total = $result->getResultCount();
+      }
+      $page++;
+    } while (count($items) < $total);
+
+    return $items;
+  }
+
+  /**
    * Fetches regular items excluding promoted ones.
    *
-   * @param \Drupal\oe_list_pages\ListSourceInterface $list_source
-   *   The list source.
-   * @param int $needed
-   *   Number of items needed.
-   * @param int $offset
-   *   The offset to start from (in regular items, not counting promoted).
-   * @param string|array $language
-   *   The language(s) to filter by.
-   * @param array $sort
-   *   The sort configuration.
-   * @param array $preset_filters
-   *   The preset filters.
-   * @param array $extra
-   *   Extra configuration.
-   * @param array $promoted_entity_ids
-   *   Entity IDs to exclude.
+   * Uses a Search API `NOT IN` condition on `search_api_id` so Solr
+   * handles the exclusion natively. This avoids the earlier offset-based
+   * PHP iteration, which relied on Solr returning promoted and regular
+   * items in identical order across separate queries — an assumption that
+   * breaks when the sort field has ties or missing values.
    *
-   * @return array
-   *   Array of Search API items.
+   * If `NOT IN` on `search_api_id` is unsupported by the backend the
+   * exception is caught and we fall back to fetching and skipping in PHP.
    */
-  protected function fetchRegularItemsExcludingPromoted(ListSourceInterface $list_source, int $needed, int $offset, $language, array $sort, array $preset_filters, array $extra, array $promoted_entity_ids): array {
-    $result_items = [];
-    $skipped = 0;
-    $page = 0;
-    // Fetch extra to account for exclusions.
-    $fetch_limit = $needed + count($promoted_entity_ids) + 10;
+  protected function fetchRegularItemsExcludingPromoted(ListSourceInterface $list_source, int $needed, int $offset, $language, array $sort, array $preset_filters, array $extra, array $promoted_item_ids): array {
+    if ($needed <= 0) {
+      return [];
+    }
 
+    // Primary path: exclude promoted items via a single Search API
+    // condition. Solr filters them out natively so the items returned are
+    // already the "regular" subset in sort order — no PHP-side skipping
+    // needed, and no dependency on two separate queries returning items
+    // in identical positions.
+    //
+    // We cannot request an arbitrary offset directly because
+    // ListSource::getQuery derives the query offset from `limit * page`.
+    // Workaround: fetch (offset + needed) items from page 0 then slice
+    // in PHP. For typical pages this stays small (< 50).
+    $query = $list_source->getQuery([
+      'limit' => $offset + $needed,
+      'page' => 0,
+      'language' => $language,
+      'sort' => $sort,
+      'preset_filters' => $preset_filters,
+      'extra' => $extra,
+    ]);
+    if (!empty($promoted_item_ids)) {
+      try {
+        // `search_api_id` is the internal item identifier
+        // (e.g. "entity:node/123:en") and is always available for filtering
+        // on Solr-backed indexes.
+        $query->addCondition('search_api_id', $promoted_item_ids, 'NOT IN');
+        $items = $query->execute()->getResultItems();
+        return array_slice($items, $offset, $needed, TRUE);
+      }
+      catch (\Exception $e) {
+        // The backend may not support NOT IN on search_api_id (e.g.
+        // database backend). Fall through to the PHP-skip strategy below.
+      }
+    }
+    else {
+      // No promoted items: a plain paginated query is enough.
+      return array_slice($query->execute()->getResultItems(), $offset, $needed, TRUE);
+    }
+
+    // Fallback path: fetch enough items to cover offset + needed + every
+    // promoted item we might encounter, then skip them manually. This is
+    // the tight worst case (all promoted items in the first batch). If it
+    // turns out to be insufficient — e.g. the total result is spread
+    // across several Solr pages — the while loop pages through naturally
+    // until we have enough, the index is exhausted, or the safety cap
+    // kicks in.
+    $result_items = [];
+    $seen_regular = 0;
+    $page = 0;
+    $fetch_limit = $offset + $needed + count($promoted_item_ids);
     while (count($result_items) < $needed) {
-      $query = $list_source->getQuery([
+      $page_query = $list_source->getQuery([
         'limit' => $fetch_limit,
         'page' => $page,
         'language' => $language,
@@ -434,44 +477,32 @@ class ListExecutionManager implements ListExecutionManagerInterface {
         'preset_filters' => $preset_filters,
         'extra' => $extra,
       ]);
-
-      $result = $query->execute();
-      $items = $result->getResultItems();
-
-      if (empty($items)) {
-        // No more items available.
+      $page_items = $page_query->execute()->getResultItems();
+      if (empty($page_items)) {
+        // No more items in the index.
         break;
       }
-
-      foreach ($items as $item_id => $item) {
-        $entity_id = $this->extractEntityIdFromItem($item);
-
-        // Skip promoted items.
-        if ($entity_id && in_array($entity_id, $promoted_entity_ids)) {
+      foreach ($page_items as $item_id => $item) {
+        // Skip promoted items — they're shown in the promoted section.
+        if (in_array($item_id, $promoted_item_ids, TRUE)) {
           continue;
         }
-
-        // Handle offset: skip items until we reach the desired offset.
-        if ($skipped < $offset) {
-          $skipped++;
+        // Skip regular items that belong to earlier pages.
+        if ($seen_regular < $offset) {
+          $seen_regular++;
           continue;
         }
-
         $result_items[$item_id] = $item;
-
         if (count($result_items) >= $needed) {
           break 2;
         }
       }
-
       $page++;
-
-      // Safety limit to prevent infinite loops.
+      // Safety cap against unbounded loops on degenerate backends.
       if ($page > 100) {
         break;
       }
     }
-
     return $result_items;
   }
 

--- a/src/ListExecutionManager.php
+++ b/src/ListExecutionManager.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\oe_list_pages;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\search_api\Item\ItemInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -42,6 +44,13 @@ class ListExecutionManager implements ListExecutionManagerInterface {
   protected $languageManager;
 
   /**
+   * The custom sort processor.
+   *
+   * @var \Drupal\oe_list_pages\CustomSortProcessor
+   */
+  protected $customSortProcessor;
+
+  /**
    * The already executed lists, keyed by entity UUID.
    *
    * @var \Drupal\oe_list_pages\ListExecutionResults[]
@@ -68,13 +77,16 @@ class ListExecutionManager implements ListExecutionManagerInterface {
    *   The language manager.
    * @param \Drupal\oe_list_pages\ListPageSortOptionsResolver $sortOptionsResolver
    *   The sort options resolver.
+   * @param \Drupal\oe_list_pages\CustomSortProcessor|null $customSortProcessor
+   *   The custom sort processor.
    */
-  public function __construct(ListSourceFactoryInterface $listSourceFactory, EntityTypeManager $entityTypeManager, RequestStack $requestStack, LanguageManagerInterface $languageManager, ListPageSortOptionsResolver $sortOptionsResolver) {
+  public function __construct(ListSourceFactoryInterface $listSourceFactory, EntityTypeManager $entityTypeManager, RequestStack $requestStack, LanguageManagerInterface $languageManager, ListPageSortOptionsResolver $sortOptionsResolver, ?CustomSortProcessor $customSortProcessor = NULL) {
     $this->listSourceFactory = $listSourceFactory;
     $this->entityTypeManager = $entityTypeManager;
     $this->requestStack = $requestStack;
     $this->languageManager = $languageManager;
     $this->sortOptionsResolver = $sortOptionsResolver;
+    $this->customSortProcessor = $customSortProcessor ?? new CustomSortProcessor();
   }
 
   /**
@@ -100,12 +112,16 @@ class ListExecutionManager implements ListExecutionManagerInterface {
     }
     $language = !empty($configuration->getLanguages()) ? $configuration->getLanguages() : $this->languageManager->getCurrentLanguage()->getId();
     $preset_filters = $configuration->getDefaultFiltersValues();
-    // If there is a sort configured use it.
-    $sort = $configuration->getSort();
+    // Build the sort array. Priority:
+    // 1. Runtime sort (from query params / user selection)
+    // 2. List page configured default sort (multi-criteria)
+    // 3. Bundle's default sort (fallback)
+    $sort = [];
+    $runtime_sort = $configuration->getSort();
 
     // Check to see if this sort is still allowed as we could have stored
     // configuration with a given sort that has been disabled.
-    if ($sort && isset($configuration->getExtra()['context_entity'])) {
+    if ($runtime_sort && isset($configuration->getExtra()['context_entity'])) {
       $context_entity_info = $configuration->getExtra()['context_entity'];
       $context_entity = $this->entityTypeManager->getStorage($context_entity_info['entity_type'])->load($context_entity_info['entity_id']);
 
@@ -114,36 +130,381 @@ class ListExecutionManager implements ListExecutionManagerInterface {
         ListPageSortOptionsResolver::SCOPE_CONFIGURATION,
         ListPageSortOptionsResolver::SCOPE_USER,
       ], $context_entity);
-      $sort_name = ListPageSortOptionsResolver::generateSortMachineName($sort);
+      $sort_name = ListPageSortOptionsResolver::generateSortMachineName($runtime_sort);
       if (!isset($options[$sort_name])) {
-        $sort = [];
+        $runtime_sort = [];
       }
     }
 
-    // If there is no configured sort, use the bundle's default sort if set.
-    $bundle_sort = $this->getBundleDefaultSort($list_source);
-    // If we have a specific sort, we use that first, followed by the default
-    // bundle sort. Otherwise, just the bundle sort.
-    $sort = $sort ? [$sort['name'] => $sort['direction']] : [];
-    if ($bundle_sort) {
-      $sort[$bundle_sort['name']] = $bundle_sort['direction'];
+    if ($runtime_sort) {
+      $sort[$runtime_sort['name']] = $runtime_sort['direction'];
     }
 
-    $options = [
+    // Apply list page's configured default sort criteria.
+    $default_sort_criteria = $configuration->getDefaultSort();
+    if (!empty($default_sort_criteria)) {
+      // Sort by weight to ensure correct order.
+      uasort($default_sort_criteria, fn($a, $b) => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+      foreach ($default_sort_criteria as $criterion) {
+        if (!empty($criterion['name']) && !isset($sort[$criterion['name']])) {
+          $sort[$criterion['name']] = $criterion['direction'] ?? 'ASC';
+        }
+      }
+    }
+
+    // Fallback to bundle's default sort if no sort configured.
+    if (empty($sort)) {
+      $bundle_sort = $this->getBundleDefaultSort($list_source);
+      if ($bundle_sort) {
+        $sort[$bundle_sort['name']] = $bundle_sort['direction'];
+      }
+    }
+
+    // Get promotion settings.
+    $promotion = $configuration->getPromotion();
+
+    // Backward compatibility: old 'values' format to new 'rules' format.
+    if (!empty($promotion['values']) && empty($promotion['rules'])) {
+      $promotion['rules'] = [];
+      foreach ($promotion['values'] as $pv) {
+        $promotion['rules'][] = [
+          'weight' => $pv['weight'] ?? 0,
+          'conditions' => [
+            [
+              'field' => $pv['field'] ?? '',
+              'operator' => '=',
+              'value' => $pv['value'] ?? '',
+            ],
+          ],
+        ];
+      }
+    }
+
+    $has_promotion = !empty($promotion['enabled']) && !empty($promotion['rules']);
+
+    // Track promoted entity IDs for marking in the UI.
+    $promoted_entity_ids = [];
+
+    // If promotion is enabled, we need a different approach:
+    // 1. First fetch promoted items (for page 0 display and to know excludes)
+    // 2. Then fetch regular items (excluding promoted ones)
+    // 3. Combine them respecting the limit and pagination.
+    if ($has_promotion) {
+      $promotion_result = $this->executeListWithPromotion(
+        $list_source,
+        $limit,
+        $current_page,
+        $language,
+        $sort,
+        $preset_filters,
+        $configuration->getExtra(),
+        $promotion
+      );
+      $result = $promotion_result['result'];
+      $promoted_entity_ids = $promotion_result['promoted_entity_ids'];
+      $query = $list_source->getQuery([
+        'limit' => $limit,
+        'page' => $current_page,
+        'language' => $language,
+        'sort' => $sort,
+        'preset_filters' => $preset_filters,
+        'extra' => $configuration->getExtra(),
+      ]);
+    }
+    else {
+      $options = [
+        'limit' => $limit,
+        'page' => $current_page,
+        'language' => $language,
+        'sort' => $sort,
+        'preset_filters' => $preset_filters,
+        'extra' => $configuration->getExtra(),
+      ];
+      $query = $list_source->getQuery($options);
+      $result = $query->execute();
+    }
+
+    $list_execution = new ListExecutionResults($query, $result, $list_source, $configuration, $promoted_entity_ids);
+
+    $this->executedLists[$configuration->getId()] = $list_execution;
+
+    return $list_execution;
+  }
+
+  /**
+   * Executes a list query with promotion support.
+   *
+   * This method fetches promoted items first, then fills the remaining slots
+   * with regular items, ensuring no duplicates and correct pagination.
+   *
+   * @param \Drupal\oe_list_pages\ListSourceInterface $list_source
+   *   The list source.
+   * @param int $limit
+   *   The number of items per page.
+   * @param int $current_page
+   *   The current page number (0-indexed).
+   * @param string|array $language
+   *   The language(s) to filter by.
+   * @param array $sort
+   *   The sort configuration.
+   * @param array $preset_filters
+   *   The preset filters.
+   * @param array $extra
+   *   Extra configuration.
+   * @param array $promotion
+   *   The promotion settings.
+   *
+   * @return array
+   *   An array with keys:
+   *   - 'result': The combined result set.
+   *   - 'promoted_entity_ids': Array of promoted entity IDs.
+   */
+  protected function executeListWithPromotion(ListSourceInterface $list_source, int $limit, int $current_page, $language, array $sort, array $preset_filters, array $extra, array $promotion): array {
+    $promoted_items = [];
+    $promoted_entity_ids = [];
+
+    // Step 1: Always fetch ALL promoted items first (we need to know the count
+    // for pagination offset calculation, and their IDs to exclude them).
+    // Each rule can have multiple conditions (combined with AND).
+    $rules = $promotion['rules'] ?? [];
+
+    foreach ($rules as $rule) {
+      $conditions = $rule['conditions'] ?? [];
+      if (empty($conditions)) {
+        continue;
+      }
+
+      // Create a query to find items matching this promotion rule.
+      // Fetch a reasonable maximum to get all promoted items.
+      $promo_query = $list_source->getQuery([
+        'limit' => 100,
+        'page' => 0,
+        'language' => $language,
+        'sort' => $sort,
+        'preset_filters' => $preset_filters,
+        'extra' => $extra,
+      ]);
+
+      // Add all conditions for this rule (AND logic).
+      foreach ($conditions as $condition) {
+        if (empty($condition['field'])) {
+          continue;
+        }
+
+        $field = $condition['field'];
+        $operator = $condition['operator'] ?? '=';
+        $value = $condition['value'] ?? '';
+
+        // Handle special value "now" for date comparisons.
+        if (strtolower($value) === 'now') {
+          $value = date('Y-m-d\TH:i:s');
+        }
+
+        // Map operators to Search API operators.
+        $promo_query->addCondition($field, $value, $operator);
+      }
+
+      $promo_result = $promo_query->execute();
+      $promo_items_found = $promo_result->getResultItems();
+
+      foreach ($promo_items_found as $item_id => $item) {
+        // Extract entity ID to avoid duplicates.
+        $entity_id = $this->extractEntityIdFromItem($item);
+        if ($entity_id && !in_array($entity_id, $promoted_entity_ids)) {
+          $promoted_items[$item_id] = $item;
+          $promoted_entity_ids[] = $entity_id;
+        }
+      }
+    }
+
+    $total_promoted = count($promoted_items);
+
+    // Step 2: Calculate pagination.
+    // Promoted items come first, then regular items follow.
+    // We need to determine which items to show based on the virtual position.
+    //
+    // Virtual list structure:
+    // [0 ... total_promoted-1] = promoted items
+    // [total_promoted ... total_items] = regular items
+    //
+    // For page N with limit L:
+    // - Start position: N * L
+    // - End position: (N + 1) * L - 1.
+    $page_start = $current_page * $limit;
+    $page_end = $page_start + $limit;
+
+    $final_items = [];
+
+    // Determine how many promoted items fall within this page's range.
+    if ($page_start < $total_promoted) {
+      // Some promoted items are on this page.
+      $promo_start = $page_start;
+      $promo_end = min($page_end, $total_promoted);
+      $promo_count = $promo_end - $promo_start;
+
+      // Get the slice of promoted items for this page.
+      $promoted_slice = array_slice($promoted_items, $promo_start, $promo_count, TRUE);
+      $final_items = $promoted_slice;
+    }
+
+    // Calculate how many regular items we need to fill the page.
+    $promoted_on_page = count($final_items);
+    $regular_needed = $limit - $promoted_on_page;
+
+    if ($regular_needed > 0) {
+      // Calculate offset for regular items.
+      // Regular items start after all promoted items in the virtual list.
+      // If we're on a page where promoted items end mid-page regular:
+      // offset = 0.
+      // If we're on a page without promoted items:
+      // offset = page_start - total_promoted.
+      $regular_offset = max(0, $page_start - $total_promoted);
+
+      // Fetch regular items excluding promoted ones.
+      $regular_items = $this->fetchRegularItemsExcludingPromoted(
+        $list_source,
+        $regular_needed,
+        $regular_offset,
+        $language,
+        $sort,
+        $preset_filters,
+        $extra,
+        $promoted_entity_ids
+      );
+
+      // Combine promoted + regular.
+      $final_items = $final_items + $regular_items;
+    }
+
+    // Create a result set with the final items.
+    // We need a base query to create a proper result set.
+    $base_query = $list_source->getQuery([
       'limit' => $limit,
       'page' => $current_page,
       'language' => $language,
       'sort' => $sort,
       'preset_filters' => $preset_filters,
-      'extra' => $configuration->getExtra(),
+      'extra' => $extra,
+    ]);
+    $base_result = $base_query->execute();
+    $base_result->setResultItems($final_items);
+
+    return [
+      'result' => $base_result,
+      'promoted_entity_ids' => $promoted_entity_ids,
     ];
-    $query = $list_source->getQuery($options);
-    $result = $query->execute();
-    $list_execution = new ListExecutionResults($query, $result, $list_source, $configuration);
+  }
 
-    $this->executedLists[$configuration->getId()] = $list_execution;
+  /**
+   * Fetches regular items excluding promoted ones.
+   *
+   * @param \Drupal\oe_list_pages\ListSourceInterface $list_source
+   *   The list source.
+   * @param int $needed
+   *   Number of items needed.
+   * @param int $offset
+   *   The offset to start from (in regular items, not counting promoted).
+   * @param string|array $language
+   *   The language(s) to filter by.
+   * @param array $sort
+   *   The sort configuration.
+   * @param array $preset_filters
+   *   The preset filters.
+   * @param array $extra
+   *   Extra configuration.
+   * @param array $promoted_entity_ids
+   *   Entity IDs to exclude.
+   *
+   * @return array
+   *   Array of Search API items.
+   */
+  protected function fetchRegularItemsExcludingPromoted(ListSourceInterface $list_source, int $needed, int $offset, $language, array $sort, array $preset_filters, array $extra, array $promoted_entity_ids): array {
+    $result_items = [];
+    $skipped = 0;
+    $page = 0;
+    // Fetch extra to account for exclusions.
+    $fetch_limit = $needed + count($promoted_entity_ids) + 10;
 
-    return $list_execution;
+    while (count($result_items) < $needed) {
+      $query = $list_source->getQuery([
+        'limit' => $fetch_limit,
+        'page' => $page,
+        'language' => $language,
+        'sort' => $sort,
+        'preset_filters' => $preset_filters,
+        'extra' => $extra,
+      ]);
+
+      $result = $query->execute();
+      $items = $result->getResultItems();
+
+      if (empty($items)) {
+        // No more items available.
+        break;
+      }
+
+      foreach ($items as $item_id => $item) {
+        $entity_id = $this->extractEntityIdFromItem($item);
+
+        // Skip promoted items.
+        if ($entity_id && in_array($entity_id, $promoted_entity_ids)) {
+          continue;
+        }
+
+        // Handle offset: skip items until we reach the desired offset.
+        if ($skipped < $offset) {
+          $skipped++;
+          continue;
+        }
+
+        $result_items[$item_id] = $item;
+
+        if (count($result_items) >= $needed) {
+          break 2;
+        }
+      }
+
+      $page++;
+
+      // Safety limit to prevent infinite loops.
+      if ($page > 100) {
+        break;
+      }
+    }
+
+    return $result_items;
+  }
+
+  /**
+   * Extracts the entity ID from a Search API item.
+   *
+   * @param \Drupal\search_api\Item\ItemInterface $item
+   *   The search result item.
+   *
+   * @return string|null
+   *   The entity ID or NULL if not extractable.
+   */
+  protected function extractEntityIdFromItem(ItemInterface $item): ?string {
+    try {
+      $original_object = $item->getOriginalObject();
+      if ($original_object) {
+        $entity = $original_object->getValue();
+        if ($entity instanceof EntityInterface) {
+          return $entity->getEntityTypeId() . ':' . $entity->id();
+        }
+      }
+    }
+    catch (\Exception $e) {
+      // Fallback: try to parse the item ID.
+    }
+
+    // Fallback: parse item ID (format: entity:node/123:en).
+    $item_id = $item->getId();
+    if (preg_match('/entity:(\w+)\/(\d+)/', $item_id, $matches)) {
+      return $matches[1] . ':' . $matches[2];
+    }
+
+    return NULL;
   }
 
   /**

--- a/src/ListExecutionResults.php
+++ b/src/ListExecutionResults.php
@@ -41,6 +41,13 @@ class ListExecutionResults implements ListExecutionResultsInterface {
   protected $configuration;
 
   /**
+   * The entity IDs of promoted (highlighted) items.
+   *
+   * @var array
+   */
+  protected $promotedEntityIds = [];
+
+  /**
    * ListExecutionResults constructor.
    *
    * @param \Drupal\search_api\Query\QueryInterface $query
@@ -51,12 +58,15 @@ class ListExecutionResults implements ListExecutionResultsInterface {
    *   The list source.
    * @param \Drupal\oe_list_pages\ListPageConfiguration $configuration
    *   The list page configuration.
+   * @param array $promotedEntityIds
+   *   (optional) The entity IDs of promoted items.
    */
-  public function __construct(QueryInterface $query, ResultSetInterface $results, ListSourceInterface $listSource, ListPageConfiguration $configuration) {
+  public function __construct(QueryInterface $query, ResultSetInterface $results, ListSourceInterface $listSource, ListPageConfiguration $configuration, array $promotedEntityIds = []) {
     $this->query = $query;
     $this->results = $results;
     $this->listSource = $listSource;
     $this->configuration = $configuration;
+    $this->promotedEntityIds = $promotedEntityIds;
   }
 
   /**
@@ -85,6 +95,13 @@ class ListExecutionResults implements ListExecutionResultsInterface {
    */
   public function getConfiguration(): ListPageConfiguration {
     return $this->configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPromotedEntityIds(): array {
+    return $this->promotedEntityIds;
   }
 
 }

--- a/src/ListExecutionResultsInterface.php
+++ b/src/ListExecutionResultsInterface.php
@@ -47,4 +47,12 @@ interface ListExecutionResultsInterface {
    */
   public function getConfiguration(): ListPageConfiguration;
 
+  /**
+   * Returns the entity IDs of promoted (highlighted) items.
+   *
+   * @return array
+   *   An array of entity IDs in the format "entity_type:entity_id".
+   */
+  public function getPromotedEntityIds(): array;
+
 }

--- a/src/ListPageConfiguration.php
+++ b/src/ListPageConfiguration.php
@@ -85,6 +85,23 @@ class ListPageConfiguration {
 
   // phpcs:disable Drupal.NamingConventions.ValidVariableName.LowerCamelName
   /**
+   * The promotion settings (items to show first).
+   *
+   * Array with 'enabled', 'field', and 'values' keys.
+   *
+   * @var array
+   */
+  protected $promotion = [];
+
+  /**
+   * The default sorting criteria for the query.
+   *
+   * Array of sort criteria, each with 'name', 'direction' and 'weight'.
+   *
+   * @var array
+   */
+  protected $default_sort = [];
+  /**
    * Whether the sort is exposed to the frontend.
    *
    * @var bool
@@ -153,6 +170,8 @@ class ListPageConfiguration {
       'exposed_filters' => $wrapper_configuration['exposed_filters'] ?? [],
       'default_filter_values' => $wrapper_configuration['preset_filters'] ?? [],
       'exposed_filters_overridden' => isset($wrapper_configuration['override_exposed_filters']) ? (bool) $wrapper_configuration['override_exposed_filters'] : FALSE,
+      'promotion' => $wrapper_configuration['promotion'] ?? [],
+      'default_sort' => $wrapper_configuration['default_sort'] ?? [],
       'limit' => $wrapper_configuration['limit'] ?? NULL,
       'page' => $wrapper_configuration['page'] ?? NULL,
       'sort' => $wrapper_configuration['sort'] ?? [],
@@ -298,6 +317,58 @@ class ListPageConfiguration {
   }
 
   /**
+   * Gets the default sort criteria.
+   *
+   * @return array
+   *   An array of sort criteria, each containing:
+   *   - name: The field name.
+   *   - direction: The sort direction (ASC/DESC).
+   *   - weight: The sort weight (for ordering).
+   */
+  public function getDefaultSort(): array {
+    return !empty($this->default_sort) ? $this->default_sort : [];
+  }
+
+  /**
+   * Sets the default sort criteria.
+   *
+   * @param array $sort_criteria
+   *   An array of sort criteria, each containing:
+   *   - name: The field name.
+   *   - direction: The sort direction (ASC/DESC).
+   *   - weight: The sort weight (for ordering).
+   */
+  public function setDefaultSort(array $sort_criteria): void {
+    $this->default_sort = $sort_criteria;
+  }
+
+  /**
+   * Gets the promotion settings.
+   *
+   * @return array
+   *   An array containing:
+   *   - enabled: Whether promotion is enabled.
+   *   - field: The field to use for promotion.
+   *   - values: Array of values to promote with weights.
+   */
+  public function getPromotion(): array {
+    return $this->promotion ?: [];
+  }
+
+  /**
+   * Sets the promotion settings.
+   *
+   * @param array $promotion
+   *   An array containing:
+   *   - enabled: Whether promotion is enabled.
+   *   - field: The field to use for promotion.
+   *   - values: Array of values to promote with weights.
+   */
+  public function setPromotion(array $promotion): void {
+    $this->promotion = $promotion;
+  }
+
+  /**
    * Returns the limit.
    *
    * @return int
@@ -423,6 +494,8 @@ class ListPageConfiguration {
       'exposed_filters_overridden' => $this->isExposedFiltersOverridden(),
       'exposed_filters' => $this->getExposedFilters(),
       'default_filter_values' => $this->getDefaultFiltersValues(),
+      'promotion' => $this->getPromotion(),
+      'default_sort' => $this->getDefaultSort(),
       'limit' => $this->getLimit(),
       'page' => $this->getPage(),
       'sort' => $this->getSort(),

--- a/src/Plugin/EntityMetaRelation/ListPage.php
+++ b/src/Plugin/EntityMetaRelation/ListPage.php
@@ -189,6 +189,8 @@ class ListPage extends EntityMetaRelationContentFormPluginBase {
     $entity_meta_configuration['override_exposed_filters'] = $configuration->isExposedFiltersOverridden();
     $entity_meta_configuration['exposed_filters'] = $configuration->getExposedFilters();
     $entity_meta_configuration['preset_filters'] = $configuration->getDefaultFiltersValues();
+    $entity_meta_configuration['promotion'] = $configuration->getPromotion();
+    $entity_meta_configuration['default_sort'] = $configuration->getDefaultSort();
     $entity_meta_configuration['limit'] = (int) $form_state->getValue([
       $this->getFormKey(),
       'limit',

--- a/templates/oe-list-pages-result-item.html.twig
+++ b/templates/oe-list-pages-result-item.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Theme implementation for a list page result item.
+ *
+ * Available variables:
+ * - content: The rendered content of the item.
+ * - is_promoted: Boolean indicating if this item is promoted/highlighted.
+ * - attributes: HTML attributes for the wrapper element.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'oe-list-pages-item',
+    is_promoted ? 'oe-list-pages-item--promoted',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% if is_promoted %}
+    <span class="oe-list-pages-promoted-badge" title="{{ 'Highlighted'|t }}">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+      </svg>
+      <span class="visually-hidden">{{ 'Highlighted item'|t }}</span>
+    </span>
+  {% endif %}
+  {{ content }}
+</div>

--- a/tests/modules/oe_list_pages_filters_test/config/install/node.type.content_type_one.yml
+++ b/tests/modules/oe_list_pages_filters_test/config/install/node.type.content_type_one.yml
@@ -9,8 +9,9 @@ third_party_settings:
       - body
       - list_facet_source_node_content_type_onestatus
     default_sort:
-      name: created
-      direction: DESC
+      - name: created
+        direction: DESC
+        weight: 0
 name: 'Content type one'
 type: content_type_one
 description: ''


### PR DESCRIPTION
<img width="200" alt="dev" src="https://github.com/user-attachments/assets/1e278a3d-331c-4d11-8228-ff5aa80bf9c3" />


You can now easily

1. set the default sorting (which field and which direction)
2. Set promoted/highlighted contents by combined criterias
for example you want to Highlight the contents of Type where tid = 11 AND  year is during 2025 and later so you will set

Field | Operator | Value 
--- | --- | --- 
Authored on | > | 01-01-2025
Type | = | 11  

UX suggestion
For a better understand of the sorting for users, we should visually distinguish promoted contents of the others. I suggest this


The visual distinction can be enable by a custom setting into /admin/structure/types/manage/oe_list_page ⟫ List Pages settings ⟫ Show visual badge on highlighted items